### PR TITLE
feat: add pepper provider with fallback backends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         std: [11, 17]
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Install Boost (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y libboost-all-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - release/**
+      - stable
+  pull_request:
+    branches:
+      - main
+      - release/**
+      - codex/**
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        std: [11, 17]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Boost (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y libboost-all-dev
+      - name: Install Boost (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          choco install boost-msvc-14.3 -y --no-progress --prerelease
+          $boost = Get-ChildItem -Path 'C:\local' -Filter 'boost_*' | Select-Object -First 1
+          "BOOST_ROOT=$($boost.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "$($boost.FullName)\lib64-msvc-14.3" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+      - name: Build
+        run: cmake --build build --config Release
+      - name: Test
+        run: ctest --test-dir build -C Release --output-on-failure

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # app-secrets-vault-example
 A minimal C++11 secrets vault for apps using PBKDF2 (from hmac-cpp) and AES-GCM (from aes-cpp). Stores email/password in JSON with Base64 fields {ver,iters,salt,iv,ct,tag}; optional code obfuscation via obfy.
+
+## Pepper provider example
+
+```cpp
+pepper::Config cfg;
+cfg.primary = pepper::StorageMode::OS_KEYCHAIN;
+cfg.fallbacks = { pepper::StorageMode::MACHINE_BOUND,
+                  pepper::StorageMode::ENCRYPTED_FILE };
+cfg.key_id = OBFY_STR("com.example.secure-example/pepper:v1");
+cfg.app_salt = { 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 };
+
+pepper::Provider prov(cfg);
+std::vector<uint8_t> pepper32;
+if (!prov.ensure(pepper32)) {
+    /* handle error */
+}
+// pepper32 now holds a 32-byte pepper derived or stored via the configured backends.
+```

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,8 +1,14 @@
-add_executable(example_simple simple.cpp)
+set(pepper_src
+    pepper/pepper_provider.cpp
+    pepper/os_keychain.cpp
+    pepper/machine_bound.cpp
+    pepper/encrypted_file.cpp)
+
+add_executable(example_simple simple.cpp ${pepper_src})
 target_link_libraries(example_simple PRIVATE aes_cpp::aes_cpp hmac_cpp::hmac_cpp obfy)
 
-add_executable(example_json json_vault.cpp)
+add_executable(example_json json_vault.cpp ${pepper_src})
 target_link_libraries(example_json PRIVATE aes_cpp::aes_cpp hmac_cpp::hmac_cpp obfy)
 
-add_executable(example_jwr jwr_vault.cpp)
+add_executable(example_jwr jwr_vault.cpp ${pepper_src})
 target_link_libraries(example_jwr PRIVATE aes_cpp::aes_cpp hmac_cpp::hmac_cpp obfy)

--- a/examples/json_vault.cpp
+++ b/examples/json_vault.cpp
@@ -12,6 +12,9 @@
 #include <hmac_cpp/encoding.hpp>
 #include <hmac_cpp/secret_string.hpp>
 #include <obfy/obfy_str.hpp>
+#include <obfy/obfy_bytes.hpp>
+
+#include "pepper/pepper_provider.hpp"
 
 #include "json.hpp"
 using json = nlohmann::json;
@@ -42,8 +45,17 @@ static std::vector<uint8_t> b64dec(const std::string& s) {
     return out;
 }
 
-static std::string pepper() {
-    return std::string(OBFY_STR("demo_pepper"));
+static const std::vector<uint8_t>& app_pepper() {
+    static std::vector<uint8_t> p;
+    if (p.empty()) {
+        pepper::Config cfg;
+        cfg.key_id = OBFY_STR("pepper:v1");
+        auto s = OBFY_BYTES("\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10");
+        cfg.app_salt = std::vector<uint8_t>(s, s + 16);
+        pepper::Provider prov(cfg);
+        if (!prov.ensure(p)) throw std::runtime_error("pepper");
+    }
+    return p;
 }
 
 static std::string serialize_vault(const VaultFile& vf) {
@@ -86,7 +98,7 @@ static std::array<uint8_t,32> derive_key(const std::string& password,
                                          const std::vector<uint8_t>& salt,
                                          uint32_t iters) {
     auto pw = to_bytes(password);
-    auto pep = to_bytes(pepper());
+    const auto& pep = app_pepper();
     auto vec = hmac_cpp::pbkdf2_with_pepper(pw, salt, pep, iters, 32);
     std::array<uint8_t,32> key{};
     std::copy(vec.begin(), vec.end(), key.begin());

--- a/examples/jwr_vault.cpp
+++ b/examples/jwr_vault.cpp
@@ -12,6 +12,9 @@
 #include <hmac_cpp/encoding.hpp>
 #include <hmac_cpp/secret_string.hpp>
 #include <obfy/obfy_str.hpp>
+#include <obfy/obfy_bytes.hpp>
+
+#include "pepper/pepper_provider.hpp"
 
 #include "json.hpp"
 using json = nlohmann::json;
@@ -42,8 +45,17 @@ static std::vector<uint8_t> b64dec(const std::string& s) {
     return out;
 }
 
-static std::string pepper() {
-    return std::string(OBFY_STR("demo_pepper"));
+static const std::vector<uint8_t>& app_pepper() {
+    static std::vector<uint8_t> p;
+    if (p.empty()) {
+        pepper::Config cfg;
+        cfg.key_id = OBFY_STR("pepper:v1");
+        auto s = OBFY_BYTES("\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10");
+        cfg.app_salt = std::vector<uint8_t>(s, s + 16);
+        pepper::Provider prov(cfg);
+        if (!prov.ensure(p)) throw std::runtime_error("pepper");
+    }
+    return p;
 }
 
 static std::string serialize_vault(const VaultFile& vf) {
@@ -86,7 +98,7 @@ static std::array<uint8_t,32> derive_key(const std::string& password,
                                          const std::vector<uint8_t>& salt,
                                          uint32_t iters) {
     auto pw = to_bytes(password);
-    auto pep = to_bytes(pepper());
+    const auto& pep = app_pepper();
     auto vec = hmac_cpp::pbkdf2_with_pepper(pw, salt, pep, iters, 32);
     std::array<uint8_t,32> key{};
     std::copy(vec.begin(), vec.end(), key.begin());

--- a/examples/pepper/encrypted_file.cpp
+++ b/examples/pepper/encrypted_file.cpp
@@ -1,0 +1,75 @@
+#include "encrypted_file.hpp"
+#include "machine_bound.hpp"
+
+#include <aes_cpp/aes_utils.hpp>
+#include <hmac_cpp/hmac_utils.hpp>
+#include <obfy/obfy_str.hpp>
+#include <obfy/obfy_bytes.hpp>
+
+#include <fstream>
+#include <array>
+#include <algorithm>
+#include <cstdlib>
+
+namespace pepper {
+namespace encrypted_file {
+
+static std::string resolve_path(const Config& cfg) {
+    if (!cfg.file_path.empty()) return cfg.file_path;
+    const char* home = std::getenv("HOME");
+    if (home) return std::string(home) + "/pepper.bin";
+    return "pepper.bin";
+}
+
+bool store(const Config& cfg, const std::vector<uint8_t>& data) {
+    auto path = resolve_path(cfg);
+    auto ms = machine_bound::get_machine_secret(cfg);
+    if (ms.empty()) return false;
+    auto prk = hmac_cpp::hkdf_extract_sha256(ms, cfg.app_salt);
+    auto ctx = std::string(OBFY_STR("pepper-file"));
+    auto key = hmac_cpp::hkdf_expand_sha256(prk, std::vector<uint8_t>(ctx.begin(), ctx.end()), 32);
+    std::array<uint8_t,32> key_arr{};
+    std::copy(key.begin(), key.end(), key_arr.begin());
+    auto enc = aes_cpp::utils::encrypt_gcm(data, key_arr, {});
+    std::ofstream of(path.c_str(), std::ios::binary);
+    if (!of) return false;
+    auto magic = OBFY_BYTES("PPR1");
+    of.write(reinterpret_cast<const char*>(magic),4);
+    of.write(reinterpret_cast<const char*>(enc.iv.data()), enc.iv.size());
+    of.write(reinterpret_cast<const char*>(enc.ciphertext.data()), enc.ciphertext.size());
+    of.write(reinterpret_cast<const char*>(enc.tag.data()), enc.tag.size());
+    return of.good();
+}
+
+bool load(const Config& cfg, std::vector<uint8_t>& out) {
+    auto path = resolve_path(cfg);
+    std::ifstream inf(path.c_str(), std::ios::binary);
+    if (!inf) return false;
+    char magic[4];
+    inf.read(magic,4);
+    auto expect = OBFY_BYTES("PPR1");
+    if (std::string(magic,4) != std::string(reinterpret_cast<const char*>(expect),4)) return false;
+    std::array<uint8_t,12> iv{};
+    inf.read(reinterpret_cast<char*>(iv.data()), iv.size());
+    std::vector<uint8_t> ct(32);
+    inf.read(reinterpret_cast<char*>(ct.data()), ct.size());
+    std::array<uint8_t,16> tag{};
+    inf.read(reinterpret_cast<char*>(tag.data()), tag.size());
+    if (!inf) return false;
+    auto ms = machine_bound::get_machine_secret(cfg);
+    if (ms.empty()) return false;
+    auto prk = hmac_cpp::hkdf_extract_sha256(ms, cfg.app_salt);
+    auto ctx = std::string(OBFY_STR("pepper-file"));
+    auto key = hmac_cpp::hkdf_expand_sha256(prk, std::vector<uint8_t>(ctx.begin(), ctx.end()), 32);
+    std::array<uint8_t,32> key_arr{};
+    std::copy(key.begin(), key.end(), key_arr.begin());
+    aes_cpp::utils::GcmEncryptedData packet;
+    packet.iv = iv;
+    packet.ciphertext = ct;
+    packet.tag = tag;
+    out = aes_cpp::utils::decrypt_gcm(packet, key_arr, {});
+    return true;
+}
+
+} // namespace encrypted_file
+} // namespace pepper

--- a/examples/pepper/encrypted_file.hpp
+++ b/examples/pepper/encrypted_file.hpp
@@ -1,0 +1,18 @@
+#ifndef PEPPER_ENCRYPTED_FILE_HPP
+#define PEPPER_ENCRYPTED_FILE_HPP
+
+#include <vector>
+#include <string>
+#include <cstdint>
+#include "pepper_provider.hpp"
+
+namespace pepper {
+namespace encrypted_file {
+
+bool load(const Config& cfg, std::vector<uint8_t>& out);
+bool store(const Config& cfg, const std::vector<uint8_t>& data);
+
+} // namespace encrypted_file
+} // namespace pepper
+
+#endif // PEPPER_ENCRYPTED_FILE_HPP

--- a/examples/pepper/machine_bound.cpp
+++ b/examples/pepper/machine_bound.cpp
@@ -1,0 +1,22 @@
+#include "machine_bound.hpp"
+#include <hmac_cpp/sha256.hpp>
+#include <fstream>
+#include <cstdlib>
+
+namespace pepper {
+namespace machine_bound {
+
+std::vector<uint8_t> get_machine_secret(const Config&) {
+    std::ifstream f("/etc/machine-id");
+    std::string id;
+    if (f) {
+        std::getline(f, id);
+    }
+    const char* user = std::getenv("USER");
+    if (user) id += user;
+    if (id.empty()) return {};
+    return hmac_hash::sha256(id.data(), id.size());
+}
+
+} // namespace machine_bound
+} // namespace pepper

--- a/examples/pepper/machine_bound.hpp
+++ b/examples/pepper/machine_bound.hpp
@@ -1,0 +1,15 @@
+#ifndef PEPPER_MACHINE_BOUND_HPP
+#define PEPPER_MACHINE_BOUND_HPP
+
+#include <vector>
+#include "pepper_provider.hpp"
+
+namespace pepper {
+namespace machine_bound {
+
+std::vector<uint8_t> get_machine_secret(const Config& cfg);
+
+} // namespace machine_bound
+} // namespace pepper
+
+#endif // PEPPER_MACHINE_BOUND_HPP

--- a/examples/pepper/os_keychain.cpp
+++ b/examples/pepper/os_keychain.cpp
@@ -1,0 +1,15 @@
+#include "os_keychain.hpp"
+
+#include <cstdint>
+
+namespace pepper {
+namespace os_keychain {
+
+bool available() { return false; }
+
+bool load(const std::string&, std::vector<uint8_t>&) { return false; }
+
+bool store(const std::string&, const std::vector<uint8_t>&) { return false; }
+
+} // namespace os_keychain
+} // namespace pepper

--- a/examples/pepper/os_keychain.hpp
+++ b/examples/pepper/os_keychain.hpp
@@ -1,0 +1,18 @@
+#ifndef PEPPER_OS_KEYCHAIN_HPP
+#define PEPPER_OS_KEYCHAIN_HPP
+
+#include <vector>
+#include <string>
+#include <cstdint>
+
+namespace pepper {
+namespace os_keychain {
+
+bool available();
+bool load(const std::string& key_id, std::vector<uint8_t>& out);
+bool store(const std::string& key_id, const std::vector<uint8_t>& data);
+
+} // namespace os_keychain
+} // namespace pepper
+
+#endif // PEPPER_OS_KEYCHAIN_HPP

--- a/examples/pepper/pepper_provider.cpp
+++ b/examples/pepper/pepper_provider.cpp
@@ -1,0 +1,67 @@
+#include "pepper_provider.hpp"
+#include "os_keychain.hpp"
+#include "machine_bound.hpp"
+#include "encrypted_file.hpp"
+
+#include <hmac_cpp/hmac_utils.hpp>
+#include <obfy/obfy_str.hpp>
+#include <obfy/obfy_call.hpp>
+
+namespace pepper {
+
+struct Provider::Impl {
+    Config cfg;
+    explicit Impl(const Config& c) : cfg(c) {}
+};
+
+Provider::Provider(const Config& cfg) : pimpl_(new Impl(cfg)) {}
+Provider::~Provider() { delete pimpl_; }
+
+static bool derive_machine(const Config& cfg, std::vector<uint8_t>& out) {
+    auto ms = machine_bound::get_machine_secret(cfg);
+    if (ms.empty()) return false;
+    auto ctx = std::string(OBFY_STR("pepper:v1"));
+    auto prk = hmac_cpp::hkdf_extract_sha256(ms, cfg.app_salt);
+    out = hmac_cpp::hkdf_expand_sha256(prk, std::vector<uint8_t>(ctx.begin(), ctx.end()), 32);
+    return true;
+}
+
+bool Provider::load(std::vector<uint8_t>& out) {
+    std::vector<StorageMode> chain = {pimpl_->cfg.primary};
+    chain.insert(chain.end(), pimpl_->cfg.fallbacks.begin(), pimpl_->cfg.fallbacks.end());
+    for (auto mode : chain) {
+        if (mode == StorageMode::OS_KEYCHAIN) {
+            if (os_keychain::available()) {
+                if (OBFY_CALL(os_keychain::load, pimpl_->cfg.key_id, out)) return true;
+            }
+        } else if (mode == StorageMode::MACHINE_BOUND) {
+            if (derive_machine(pimpl_->cfg, out)) return true;
+        } else if (mode == StorageMode::ENCRYPTED_FILE) {
+            if (encrypted_file::load(pimpl_->cfg, out)) return true;
+        }
+    }
+    return false;
+}
+
+bool Provider::ensure(std::vector<uint8_t>& out) {
+    std::vector<StorageMode> chain = {pimpl_->cfg.primary};
+    chain.insert(chain.end(), pimpl_->cfg.fallbacks.begin(), pimpl_->cfg.fallbacks.end());
+    for (auto mode : chain) {
+        if (mode == StorageMode::OS_KEYCHAIN) {
+            if (os_keychain::available()) {
+                if (OBFY_CALL(os_keychain::load, pimpl_->cfg.key_id, out)) return true;
+                auto p = hmac_cpp::random_bytes(32);
+                if (OBFY_CALL(os_keychain::store, pimpl_->cfg.key_id, p)) { out = p; return true; }
+            }
+        } else if (mode == StorageMode::MACHINE_BOUND) {
+            if (derive_machine(pimpl_->cfg, out)) return true;
+        } else if (mode == StorageMode::ENCRYPTED_FILE) {
+            if (encrypted_file::load(pimpl_->cfg, out)) return true;
+            auto p = hmac_cpp::random_bytes(32);
+            if (encrypted_file::store(pimpl_->cfg, p)) { out = p; return true; }
+        }
+    }
+    return false;
+}
+
+} // namespace pepper

--- a/examples/pepper/pepper_provider.hpp
+++ b/examples/pepper/pepper_provider.hpp
@@ -1,0 +1,41 @@
+#ifndef PEPPER_PROVIDER_HPP
+#define PEPPER_PROVIDER_HPP
+
+#include <vector>
+#include <string>
+#include <cstdint>
+
+namespace pepper {
+
+// Where to keep the secret
+enum class StorageMode {
+    OS_KEYCHAIN,
+    MACHINE_BOUND,
+    ENCRYPTED_FILE
+};
+
+struct Config {
+    StorageMode primary = StorageMode::OS_KEYCHAIN;
+    std::vector<StorageMode> fallbacks = { StorageMode::MACHINE_BOUND, StorageMode::ENCRYPTED_FILE };
+    std::string key_id = "pepper:v1";
+    std::string file_path;
+    bool use_os_wrap_if_possible = true;
+    std::vector<uint8_t> app_salt; // 16..32 bytes
+};
+
+class Provider {
+public:
+    explicit Provider(const Config& cfg);
+    ~Provider();
+
+    bool ensure(std::vector<uint8_t>& out);
+    bool load(std::vector<uint8_t>& out);
+
+private:
+    struct Impl;
+    Impl* pimpl_;
+};
+
+} // namespace pepper
+
+#endif // PEPPER_PROVIDER_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,13 @@
 add_executable(vault_tests test_vault.cpp)
 target_link_libraries(vault_tests PRIVATE aes_cpp::aes_cpp hmac_cpp::hmac_cpp obfy)
 add_test(NAME vault_tests COMMAND vault_tests)
+
+add_executable(pepper_tests
+    test_pepper.cpp
+    ../examples/pepper/pepper_provider.cpp
+    ../examples/pepper/os_keychain.cpp
+    ../examples/pepper/machine_bound.cpp
+    ../examples/pepper/encrypted_file.cpp)
+target_include_directories(pepper_tests PRIVATE ../examples/pepper)
+target_link_libraries(pepper_tests PRIVATE aes_cpp::aes_cpp hmac_cpp::hmac_cpp obfy)
+add_test(NAME pepper_tests COMMAND pepper_tests)

--- a/test/test_pepper.cpp
+++ b/test/test_pepper.cpp
@@ -1,0 +1,43 @@
+#include <cassert>
+#include <vector>
+#include <fstream>
+#include <cstdint>
+
+#include "../examples/pepper/pepper_provider.hpp"
+#include "../examples/pepper/encrypted_file.hpp"
+
+static std::vector<uint8_t> salt16() {
+    std::vector<uint8_t> s(16);
+    for (size_t i = 0; i < s.size(); ++i) s[i] = static_cast<uint8_t>(i + 1);
+    return s;
+}
+
+static void test_machine_bound() {
+    pepper::Config c1; c1.primary = pepper::StorageMode::MACHINE_BOUND; c1.app_salt = salt16();
+    pepper::Provider p1(c1); std::vector<uint8_t> a; assert(p1.ensure(a)); assert(a.size()==32);
+    pepper::Provider p1b(c1); std::vector<uint8_t> b; assert(p1b.ensure(b)); assert(a==b);
+    pepper::Config c2 = c1; c2.app_salt[0] ^= 0xFF; pepper::Provider p2(c2); std::vector<uint8_t> c; assert(p2.ensure(c)); assert(a!=c);
+}
+
+static void test_encrypted_file() {
+    pepper::Config cfg; cfg.primary = pepper::StorageMode::ENCRYPTED_FILE; cfg.file_path = "pepper_test.bin"; cfg.app_salt = salt16();
+    { pepper::Provider p(cfg); std::vector<uint8_t> a; assert(p.ensure(a)); }
+    pepper::Provider p2(cfg); std::vector<uint8_t> b; assert(p2.ensure(b));
+    pepper::Provider p3(cfg); std::vector<uint8_t> c; assert(p3.load(c)); assert(b==c);
+    std::ofstream(cfg.file_path, std::ios::binary|std::ios::trunc) << "bad";
+    cfg.fallbacks.clear();
+    pepper::Provider p4(cfg); std::vector<uint8_t> d; assert(!p4.load(d));
+}
+
+static void test_fallback() {
+    pepper::Config cfg; cfg.primary = pepper::StorageMode::OS_KEYCHAIN; cfg.fallbacks = {pepper::StorageMode::MACHINE_BOUND}; cfg.app_salt = salt16();
+    pepper::Provider p(cfg); std::vector<uint8_t> a; assert(p.ensure(a)); assert(a.size()==32);
+}
+
+int main() {
+    test_machine_bound();
+    test_encrypted_file();
+    test_fallback();
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add Pepper::Provider with OS keychain stub, machine-bound derivation and encrypted file storage
- document pepper provider usage and add tests
- integrate Pepper::Provider into example apps and simplify default key id
- add GitHub Actions workflow to build and test on Ubuntu and Windows

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bf727b02e4832c923e20f4066ad1e1