### PR TITLE
feat: secure buffers, versioned JSON, and atomic vault writes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(app_secrets_vault_example LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Disable tests/examples in third-party libs

--- a/examples/file_io.hpp
+++ b/examples/file_io.hpp
@@ -1,0 +1,95 @@
+#pragma once
+#include <string>
+#include <filesystem>
+#include <stdexcept>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <aclapi.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#endif
+
+namespace demo {
+inline void atomic_write_file(const std::string& path, const std::string& data) {
+    namespace fs = std::filesystem;
+    fs::path target(path);
+    fs::path tmp = target;
+    tmp += ".tmp";
+#ifdef _WIN32
+    std::wstring wtmp = tmp.wstring();
+    HANDLE h = CreateFileW(wtmp.c_str(), GENERIC_WRITE, 0, nullptr,
+                           CREATE_ALWAYS, FILE_ATTRIBUTE_TEMPORARY, nullptr);
+    if (h == INVALID_HANDLE_VALUE) throw std::runtime_error("open");
+    DWORD written = 0;
+    if (!WriteFile(h, data.data(), static_cast<DWORD>(data.size()), &written, nullptr) ||
+        written != data.size()) {
+        CloseHandle(h);
+        DeleteFileW(wtmp.c_str());
+        throw std::runtime_error("write");
+    }
+    if (!FlushFileBuffers(h)) {
+        CloseHandle(h);
+        DeleteFileW(wtmp.c_str());
+        throw std::runtime_error("flush");
+    }
+    CloseHandle(h);
+    std::wstring wfinal = target.wstring();
+    if (!MoveFileExW(wtmp.c_str(), wfinal.c_str(), MOVEFILE_REPLACE_EXISTING)) {
+        DeleteFileW(wtmp.c_str());
+        throw std::runtime_error("rename");
+    }
+    SetFileAttributesW(wfinal.c_str(), FILE_ATTRIBUTE_HIDDEN);
+    HANDLE token = INVALID_HANDLE_VALUE;
+    if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+        DWORD len = 0;
+        GetTokenInformation(token, TokenUser, nullptr, 0, &len);
+        std::vector<char> buf(len);
+        if (GetTokenInformation(token, TokenUser, buf.data(), len, &len)) {
+            TOKEN_USER* tu = reinterpret_cast<TOKEN_USER*>(buf.data());
+            EXPLICIT_ACCESSW ea{};
+            ea.grfAccessPermissions = GENERIC_ALL;
+            ea.grfAccessMode = SET_ACCESS;
+            ea.grfInheritance = SUB_CONTAINERS_AND_OBJECTS_INHERIT;
+            ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+            ea.Trustee.TrusteeType = TRUSTEE_IS_USER;
+            ea.Trustee.ptstrName = (LPWSTR)tu->User.Sid;
+            PACL acl = nullptr;
+            if (SetEntriesInAclW(1, &ea, nullptr, &acl) == ERROR_SUCCESS) {
+                SetNamedSecurityInfoW((LPWSTR)wfinal.c_str(), SE_FILE_OBJECT,
+                                      DACL_SECURITY_INFORMATION, nullptr, nullptr, acl, nullptr);
+                LocalFree(acl);
+            }
+        }
+        CloseHandle(token);
+    }
+#else
+    int fd = ::open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) throw std::runtime_error("open");
+    ssize_t written = ::write(fd, data.data(), data.size());
+    if (written != static_cast<ssize_t>(data.size())) {
+        ::close(fd);
+        ::unlink(tmp.c_str());
+        throw std::runtime_error("write");
+    }
+    if (::fsync(fd) != 0) {
+        ::close(fd);
+        ::unlink(tmp.c_str());
+        throw std::runtime_error("fsync");
+    }
+    if (::close(fd) != 0) {
+        ::unlink(tmp.c_str());
+        throw std::runtime_error("close");
+    }
+    std::error_code ec;
+    fs::rename(tmp, target, ec);
+    if (ec) {
+        ::unlink(tmp.c_str());
+        throw std::runtime_error("rename");
+    }
+#endif
+}
+} // namespace demo

--- a/examples/json_vault.cpp
+++ b/examples/json_vault.cpp
@@ -11,49 +11,47 @@
 #include <hmac_cpp/hmac_utils.hpp>
 #include <hmac_cpp/encoding.hpp>
 #include <hmac_cpp/secret_string.hpp>
+#include <hmac_cpp/secure_buffer.hpp>
 #include <obfy/obfy_str.hpp>
 #include <obfy/obfy_bytes.hpp>
 
 #include "pepper/pepper_provider.hpp"
 
 #include "json.hpp"
+#include "file_io.hpp"
 using json = nlohmann::json;
 
 struct VaultFile {
     uint32_t v = 1;
     uint32_t iters;
-    std::vector<uint8_t> salt;
-    std::vector<uint8_t> iv;
-    std::vector<uint8_t> tag;
-    std::vector<uint8_t> ct;
+    hmac_cpp::secure_buffer<uint8_t, true> salt;
+    hmac_cpp::secure_buffer<uint8_t, true> iv;
+    hmac_cpp::secure_buffer<uint8_t, true> tag;
+    hmac_cpp::secure_buffer<uint8_t, true> ct;
     std::string aad;
 };
 
-static std::vector<uint8_t> to_bytes(const std::string& s) {
-    return std::vector<uint8_t>(s.begin(), s.end());
-}
-static std::string to_string(const std::vector<uint8_t>& v) {
-    return std::string(v.begin(), v.end());
-}
-
-static std::string b64enc(const std::vector<uint8_t>& v) {
-    return hmac_cpp::base64_encode(v);
-}
-static std::vector<uint8_t> b64dec(const std::string& s) {
-    std::vector<uint8_t> out;
-    if (!hmac_cpp::base64_decode(s, out)) throw std::runtime_error("b64");
-    return out;
+static hmac_cpp::secure_buffer<uint8_t, true> b64dec(const std::string& s) {
+    std::vector<uint8_t> tmp;
+    if (!hmac_cpp::base64_decode(s, tmp)) throw std::runtime_error("b64");
+    return hmac_cpp::secure_buffer<uint8_t, true>(std::move(tmp));
 }
 
-static const std::vector<uint8_t>& app_pepper() {
-    static std::vector<uint8_t> p;
-    if (p.empty()) {
+static std::string b64enc(const hmac_cpp::secure_buffer<uint8_t, true>& v) {
+    return hmac_cpp::base64_encode(v.data(), v.size());
+}
+
+static const hmac_cpp::secure_buffer<uint8_t, true>& app_pepper() {
+    static hmac_cpp::secure_buffer<uint8_t, true> p;
+    if (p.size()==0) {
         pepper::Config cfg;
         cfg.key_id = OBFY_STR("pepper:v1");
         auto s = OBFY_BYTES("\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10");
         cfg.app_salt = std::vector<uint8_t>(s, s + 16);
         pepper::Provider prov(cfg);
-        if (!prov.ensure(p)) throw std::runtime_error("pepper");
+        std::vector<uint8_t> tmp;
+        if (!prov.ensure(tmp)) throw std::runtime_error("pepper");
+        p = hmac_cpp::secure_buffer<uint8_t, true>(std::move(tmp));
     }
     return p;
 }
@@ -61,18 +59,17 @@ static const std::vector<uint8_t>& app_pepper() {
 static std::string serialize_vault(const VaultFile& vf) {
     json j;
     j["v"] = vf.v;
+    j["aead"] = "AES-256-GCM";
     j["kdf"] = {
-        {"name","PBKDF2-HMAC-SHA256"},
+        {"prf","PBKDF2-HMAC-SHA256"},
         {"iters", vf.iters},
-        {"salt", b64enc(vf.salt)},
-        {"dkLen", 32}
+        {"salt", b64enc(vf.salt)}
     };
-    j["aead"] = {
-        {"alg","AES-256-GCM"},
+    j["enc"] = {
         {"iv",  b64enc(vf.iv)},
+        {"ct",  b64enc(vf.ct)},
         {"tag", b64enc(vf.tag)}
     };
-    j["ciphertext"] = b64enc(vf.ct);
     if (!vf.aad.empty()) j["aad"] = vf.aad;
     return j.dump(2);
 }
@@ -81,28 +78,37 @@ static VaultFile parse_vault(const std::string& s) {
     auto j = json::parse(s);
     VaultFile vf;
     vf.v = j.at("v").get<uint32_t>();
+    if (vf.v != 1) throw std::runtime_error("bad version");
+    if (j.at("aead").get<std::string>() != "AES-256-GCM")
+        throw std::runtime_error("bad aead");
     auto jk = j.at("kdf");
     vf.iters = jk.at("iters").get<uint32_t>();
+    if (vf.iters < 100000 || vf.iters > 1000000)
+        throw std::runtime_error("bad iters");
     vf.salt  = b64dec(jk.at("salt").get<std::string>());
-
-    auto ja = j.at("aead");
-    vf.iv   = b64dec(ja.at("iv").get<std::string>());
-    vf.tag  = b64dec(ja.at("tag").get<std::string>());
-
-    vf.ct   = b64dec(j.at("ciphertext").get<std::string>());
+    if (vf.salt.size() < 16 || vf.salt.size() > 32)
+        throw std::runtime_error("bad salt size");
+    auto je = j.at("enc");
+    vf.iv   = b64dec(je.at("iv").get<std::string>());
+    if (vf.iv.size() != 12) throw std::runtime_error("bad iv size");
+    vf.ct   = b64dec(je.at("ct").get<std::string>());
+    vf.tag  = b64dec(je.at("tag").get<std::string>());
+    if (vf.tag.size() != 16) throw std::runtime_error("bad tag size");
     vf.aad  = j.value("aad", "");
     return vf;
 }
 
-static std::array<uint8_t,32> derive_key(const std::string& password,
-                                         const std::vector<uint8_t>& salt,
-                                         uint32_t iters) {
-    auto pw = to_bytes(password);
-    const auto& pep = app_pepper();
-    auto vec = hmac_cpp::pbkdf2_with_pepper(pw, salt, pep, iters, 32);
-    std::array<uint8_t,32> key{};
-    std::copy(vec.begin(), vec.end(), key.begin());
-    return key;
+static hmac_cpp::secure_buffer<uint8_t, true> derive_key(
+        const std::string& password,
+        const hmac_cpp::secure_buffer<uint8_t, true>& salt,
+        uint32_t iters) {
+    std::string pw_copy(password);
+    hmac_cpp::secure_buffer<uint8_t, true> pw(std::move(pw_copy));
+    auto vec = hmac_cpp::pbkdf2_with_pepper(pw.data(), pw.size(),
+                                            salt.data(), salt.size(),
+                                            app_pepper().data(), app_pepper().size(),
+                                            iters, 32);
+    return hmac_cpp::secure_buffer<uint8_t, true>(std::move(vec));
 }
 
 static VaultFile create_vault(const std::string& master_password,
@@ -114,34 +120,45 @@ static VaultFile create_vault(const std::string& master_password,
     VaultFile vf;
     vf.v = 1;
     vf.iters = iters;
-    vf.salt = hmac_cpp::random_bytes(16);
+    vf.salt = hmac_cpp::secure_buffer<uint8_t, true>(hmac_cpp::random_bytes(16));
     auto key = derive_key(master_password, vf.salt, iters);
+    std::array<uint8_t,32> key_arr{};
+    std::copy(key.begin(), key.begin()+key_arr.size(), key_arr.begin());
 
     json payload = { {"email", email}, {"password", password} };
-    auto plain = to_bytes(payload.dump());
+    std::string payload_str = payload.dump();
+    hmac_cpp::secure_buffer<uint8_t, true> plain(std::move(payload_str));
 
-    std::vector<uint8_t> aad_bytes = to_bytes(aad);
-    auto enc = aes_cpp::utils::encrypt_gcm(plain, key, aad_bytes);
-    vf.iv.assign(enc.iv.begin(), enc.iv.end());
-    vf.ct  = std::move(enc.ciphertext);
-    vf.tag.assign(enc.tag.begin(), enc.tag.end());
+    std::vector<uint8_t> aad_bytes(aad.begin(), aad.end());
+    std::vector<uint8_t> plain_vec(plain.begin(), plain.end());
+    auto enc = aes_cpp::utils::encrypt_gcm(plain_vec, key_arr, aad_bytes);
+    hmac_cpp::secure_zero(key_arr.data(), key_arr.size());
+    hmac_cpp::secure_zero(plain_vec.data(), plain_vec.size());
+    vf.iv = hmac_cpp::secure_buffer<uint8_t, true>(std::vector<uint8_t>(enc.iv.begin(), enc.iv.end()));
+    vf.ct = hmac_cpp::secure_buffer<uint8_t, true>(std::move(enc.ciphertext));
+    vf.tag = hmac_cpp::secure_buffer<uint8_t, true>(std::vector<uint8_t>(enc.tag.begin(), enc.tag.end()));
     vf.aad = aad;
     return vf;
 }
 
 static json open_vault(const std::string& master_password, const VaultFile& vf) {
     auto key = derive_key(master_password, vf.salt, vf.iters);
+    std::array<uint8_t,32> key_arr{};
+    std::copy(key.begin(), key.begin()+key_arr.size(), key_arr.begin());
     std::array<uint8_t,12> iv{};
-    if (vf.iv.size()!=iv.size()) throw std::runtime_error("bad iv size");
-    std::copy(vf.iv.begin(), vf.iv.end(), iv.begin());
+    std::copy(vf.iv.begin(), vf.iv.begin() + iv.size(), iv.begin());
     std::array<uint8_t,16> tag{};
-    if (vf.tag.size()!=tag.size()) throw std::runtime_error("bad tag size");
-    std::copy(vf.tag.begin(), vf.tag.end(), tag.begin());
+    std::copy(vf.tag.begin(), vf.tag.begin() + tag.size(), tag.begin());
 
-    std::vector<uint8_t> aad_bytes = to_bytes(vf.aad);
-    aes_cpp::utils::GcmEncryptedData pkt{std::chrono::system_clock::now(), iv, vf.ct, tag};
-    auto plain = aes_cpp::utils::decrypt_gcm_to_string(pkt, key, aad_bytes);
-    return json::parse(plain);
+    std::vector<uint8_t> aad_bytes(vf.aad.begin(), vf.aad.end());
+    std::vector<uint8_t> ct_vec(vf.ct.begin(), vf.ct.end());
+    aes_cpp::utils::GcmEncryptedData pkt{std::chrono::system_clock::now(), iv, ct_vec, tag};
+    auto plain = aes_cpp::utils::decrypt_gcm_to_string(pkt, key_arr, aad_bytes);
+    hmac_cpp::secure_zero(key_arr.data(), key_arr.size());
+    hmac_cpp::secure_zero(ct_vec.data(), ct_vec.size());
+    auto j = json::parse(plain);
+    hmac_cpp::secure_zero(&plain[0], plain.size());
+    return j;
 }
 
 int main() {
@@ -152,12 +169,15 @@ int main() {
 
         auto vf = create_vault(master, email, pass, 300000, "app=demo;v=1");
         auto text = serialize_vault(vf);
-        std::ofstream("vault.json") << text;
+        demo::atomic_write_file("vault.json", text);
         std::cout << "Saved JSON:\n" << text << "\n";
 
         std::ifstream ifs("vault.json");
         std::stringstream buffer; buffer << ifs.rdbuf();
-        VaultFile vf2 = parse_vault(buffer.str());
+        std::string blob = buffer.str();
+        VaultFile vf2 = parse_vault(blob);
+        hmac_cpp::secure_zero(&blob[0], blob.size());
+        blob.clear();
         auto payload  = open_vault(master, vf2);
         hmac_cpp::secret_string em(payload.at("email").get<std::string>());
         hmac_cpp::secret_string pw(payload.at("password").get<std::string>());

--- a/examples/jwr_vault.cpp
+++ b/examples/jwr_vault.cpp
@@ -11,21 +11,23 @@
 #include <hmac_cpp/hmac_utils.hpp>
 #include <hmac_cpp/encoding.hpp>
 #include <hmac_cpp/secret_string.hpp>
+#include <hmac_cpp/secure_buffer.hpp>
 #include <obfy/obfy_str.hpp>
 #include <obfy/obfy_bytes.hpp>
 
 #include "pepper/pepper_provider.hpp"
 
 #include "json.hpp"
+#include "file_io.hpp"
 using json = nlohmann::json;
 
 struct VaultFile {
     uint32_t v = 1;
     uint32_t iters;
-    std::vector<uint8_t> salt;
-    std::vector<uint8_t> iv;
-    std::vector<uint8_t> tag;
-    std::vector<uint8_t> ct;
+    hmac_cpp::secure_buffer<uint8_t, true> salt;
+    hmac_cpp::secure_buffer<uint8_t, true> iv;
+    hmac_cpp::secure_buffer<uint8_t, true> tag;
+    hmac_cpp::secure_buffer<uint8_t, true> ct;
     std::string aad;
 };
 
@@ -36,24 +38,31 @@ static std::string to_string(const std::vector<uint8_t>& v) {
     return std::string(v.begin(), v.end());
 }
 
-static std::string b64enc(const std::vector<uint8_t>& v) {
-    return hmac_cpp::base64_encode(v);
+static std::string b64enc(const hmac_cpp::secure_buffer<uint8_t, true>& v) {
+    return hmac_cpp::base64_encode(v.data(), v.size());
 }
-static std::vector<uint8_t> b64dec(const std::string& s) {
-    std::vector<uint8_t> out;
-    if (!hmac_cpp::base64_decode(s, out)) throw std::runtime_error("b64");
-    return out;
+static hmac_cpp::secure_buffer<uint8_t, true> b64dec(const std::string& s) {
+    std::vector<uint8_t> tmp;
+    if (!hmac_cpp::base64_decode(s, tmp)) throw std::runtime_error("b64");
+    return hmac_cpp::secure_buffer<uint8_t, true>(std::move(tmp));
 }
 
-static const std::vector<uint8_t>& app_pepper() {
-    static std::vector<uint8_t> p;
-    if (p.empty()) {
+static const hmac_cpp::secure_buffer<uint8_t, true>& app_pepper() {
+    static hmac_cpp::secure_buffer<uint8_t, true> p;
+    if (p.size() == 0) {
         pepper::Config cfg;
-        cfg.key_id = OBFY_STR("pepper:v1");
-        auto s = OBFY_BYTES("\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10");
-        cfg.app_salt = std::vector<uint8_t>(s, s + 16);
+        auto kid_tmp = OBFY_STR_ONCE("pepper:v1");
+        std::string kid(kid_tmp);
+        cfg.key_id = kid;
+        hmac_cpp::secure_zero(&kid[0], kid.size());
+        auto s_tmp = OBFY_BYTES_ONCE("\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10");
+        std::vector<uint8_t> s(s_tmp.data(), s_tmp.data() + s_tmp.size());
+        cfg.app_salt = s;
+        hmac_cpp::secure_zero(s.data(), s.size());
         pepper::Provider prov(cfg);
-        if (!prov.ensure(p)) throw std::runtime_error("pepper");
+        std::vector<uint8_t> tmp;
+        if (!prov.ensure(tmp)) throw std::runtime_error("pepper");
+        p = hmac_cpp::secure_buffer<uint8_t, true>(std::move(tmp));
     }
     return p;
 }
@@ -81,8 +90,11 @@ static VaultFile parse_vault(const std::string& s) {
     auto j = json::parse(s);
     VaultFile vf;
     vf.v = j.at("v").get<uint32_t>();
+    if (vf.v != 1) throw std::runtime_error("bad version");
     auto jk = j.at("kdf");
     vf.iters = jk.at("iters").get<uint32_t>();
+    if (vf.iters < 100000 || vf.iters > 1000000)
+        throw std::runtime_error("bad iters");
     vf.salt  = b64dec(jk.at("salt").get<std::string>());
 
     auto ja = j.at("aead");
@@ -94,15 +106,17 @@ static VaultFile parse_vault(const std::string& s) {
     return vf;
 }
 
-static std::array<uint8_t,32> derive_key(const std::string& password,
-                                         const std::vector<uint8_t>& salt,
-                                         uint32_t iters) {
-    auto pw = to_bytes(password);
-    const auto& pep = app_pepper();
-    auto vec = hmac_cpp::pbkdf2_with_pepper(pw, salt, pep, iters, 32);
-    std::array<uint8_t,32> key{};
-    std::copy(vec.begin(), vec.end(), key.begin());
-    return key;
+static hmac_cpp::secure_buffer<uint8_t, true> derive_key(
+        const std::string& password,
+        const hmac_cpp::secure_buffer<uint8_t, true>& salt,
+        uint32_t iters) {
+    std::string pw_copy(password);
+    hmac_cpp::secure_buffer<uint8_t, true> pw(std::move(pw_copy));
+    auto vec = hmac_cpp::pbkdf2_with_pepper(pw.data(), pw.size(),
+                                            salt.data(), salt.size(),
+                                            app_pepper().data(), app_pepper().size(),
+                                            iters, 32);
+    return hmac_cpp::secure_buffer<uint8_t, true>(std::move(vec));
 }
 
 static VaultFile create_vault(const std::string& master_password,
@@ -114,34 +128,47 @@ static VaultFile create_vault(const std::string& master_password,
     VaultFile vf;
     vf.v = 1;
     vf.iters = iters;
-    vf.salt = hmac_cpp::random_bytes(16);
+    vf.salt = hmac_cpp::secure_buffer<uint8_t, true>(hmac_cpp::random_bytes(16));
     auto key = derive_key(master_password, vf.salt, iters);
+    std::array<uint8_t,32> key_arr{};
+    std::copy(key.begin(), key.begin()+key_arr.size(), key_arr.begin());
 
     json payload = { {"email", email}, {"password", password} };
-    auto plain = to_bytes(payload.dump());
+    std::string payload_str = payload.dump();
+    hmac_cpp::secure_buffer<uint8_t, true> plain(std::move(payload_str));
 
     std::vector<uint8_t> aad_bytes = to_bytes(aad);
-    auto enc = aes_cpp::utils::encrypt_gcm(plain, key, aad_bytes);
-    vf.iv.assign(enc.iv.begin(), enc.iv.end());
-    vf.ct  = std::move(enc.ciphertext);
-    vf.tag.assign(enc.tag.begin(), enc.tag.end());
+    std::vector<uint8_t> plain_vec(plain.begin(), plain.end());
+    auto enc = aes_cpp::utils::encrypt_gcm(plain_vec, key_arr, aad_bytes);
+    hmac_cpp::secure_zero(key_arr.data(), key_arr.size());
+    hmac_cpp::secure_zero(plain_vec.data(), plain_vec.size());
+    vf.iv = hmac_cpp::secure_buffer<uint8_t, true>(std::vector<uint8_t>(enc.iv.begin(), enc.iv.end()));
+    vf.ct = hmac_cpp::secure_buffer<uint8_t, true>(std::move(enc.ciphertext));
+    vf.tag = hmac_cpp::secure_buffer<uint8_t, true>(std::vector<uint8_t>(enc.tag.begin(), enc.tag.end()));
     vf.aad = aad;
     return vf;
 }
 
 static json open_vault(const std::string& master_password, const VaultFile& vf) {
     auto key = derive_key(master_password, vf.salt, vf.iters);
+    std::array<uint8_t,32> key_arr{};
+    std::copy(key.begin(), key.begin()+key_arr.size(), key_arr.begin());
     std::array<uint8_t,12> iv{};
     if (vf.iv.size()!=iv.size()) throw std::runtime_error("bad iv size");
-    std::copy(vf.iv.begin(), vf.iv.end(), iv.begin());
+    std::copy(vf.iv.begin(), vf.iv.begin()+iv.size(), iv.begin());
     std::array<uint8_t,16> tag{};
     if (vf.tag.size()!=tag.size()) throw std::runtime_error("bad tag size");
-    std::copy(vf.tag.begin(), vf.tag.end(), tag.begin());
+    std::copy(vf.tag.begin(), vf.tag.begin()+tag.size(), tag.begin());
 
     std::vector<uint8_t> aad_bytes = to_bytes(vf.aad);
-    aes_cpp::utils::GcmEncryptedData pkt{std::chrono::system_clock::now(), iv, vf.ct, tag};
-    auto plain = aes_cpp::utils::decrypt_gcm_to_string(pkt, key, aad_bytes);
-    return json::parse(plain);
+    std::vector<uint8_t> ct_vec(vf.ct.begin(), vf.ct.end());
+    aes_cpp::utils::GcmEncryptedData pkt{std::chrono::system_clock::now(), iv, ct_vec, tag};
+    auto plain = aes_cpp::utils::decrypt_gcm_to_string(pkt, key_arr, aad_bytes);
+    hmac_cpp::secure_zero(key_arr.data(), key_arr.size());
+    hmac_cpp::secure_zero(ct_vec.data(), ct_vec.size());
+    auto j = json::parse(plain);
+    hmac_cpp::secure_zero(&plain[0], plain.size());
+    return j;
 }
 
 static std::string b64url_encode(const std::vector<uint8_t>& data) {
@@ -152,14 +179,15 @@ static std::string b64url_encode(const std::vector<uint8_t>& data) {
     return s;
 }
 
-static std::vector<uint8_t> b64url_decode(const std::string& s) {
+static hmac_cpp::secure_buffer<uint8_t, true> b64url_decode(const std::string& s) {
     std::string t = s;
     std::replace(t.begin(), t.end(), '-', '+');
     std::replace(t.begin(), t.end(), '_', '/');
     while (t.size() % 4) t.push_back('=');
     std::vector<uint8_t> out;
     if (!hmac_cpp::base64_decode(t, out)) throw std::runtime_error("b64");
-    return out;
+    hmac_cpp::secure_zero(&t[0], t.size());
+    return hmac_cpp::secure_buffer<uint8_t, true>(std::move(out));
 }
 
 static std::string create_token(const std::string& master,
@@ -175,6 +203,7 @@ static std::string create_token(const std::string& master,
     std::string body = serialize_vault(vf);
     std::string token = b64url_encode(to_bytes(head)) + "." +
                         b64url_encode(to_bytes(body));
+    hmac_cpp::secure_zero(&body[0], body.size());
     return token;
 }
 
@@ -184,6 +213,7 @@ static json open_token(const std::string& master, const std::string& token) {
     std::string body_b64 = token.substr(pos+1);
     auto body_bytes = b64url_decode(body_b64);
     VaultFile vf = parse_vault(std::string(body_bytes.begin(), body_bytes.end()));
+    hmac_cpp::secure_zero(body_bytes.data(), body_bytes.size());
     return open_vault(master, vf);
 }
 
@@ -194,7 +224,7 @@ int main() {
         const std::string pass    = "s3cr3t!";
 
         auto token = create_token(master, email, pass);
-        std::ofstream("vault.jwr") << token;
+        demo::atomic_write_file("vault.jwr", token);
         std::cout << "Token: " << token << "\n";
 
         std::string read_token;

--- a/test/test_pepper.cpp
+++ b/test/test_pepper.cpp
@@ -3,6 +3,9 @@
 #include <fstream>
 #include <cstdint>
 
+#include <hmac_cpp/hmac_utils.hpp>
+#include <hmac_cpp/secure_buffer.hpp>
+
 #include "../examples/pepper/pepper_provider.hpp"
 #include "../examples/pepper/encrypted_file.hpp"
 
@@ -15,15 +18,23 @@ static std::vector<uint8_t> salt16() {
 static void test_machine_bound() {
     pepper::Config c1; c1.primary = pepper::StorageMode::MACHINE_BOUND; c1.app_salt = salt16();
     pepper::Provider p1(c1); std::vector<uint8_t> a; assert(p1.ensure(a)); assert(a.size()==32);
-    pepper::Provider p1b(c1); std::vector<uint8_t> b; assert(p1b.ensure(b)); assert(a==b);
-    pepper::Config c2 = c1; c2.app_salt[0] ^= 0xFF; pepper::Provider p2(c2); std::vector<uint8_t> c; assert(p2.ensure(c)); assert(a!=c);
+    pepper::Provider p1b(c1); std::vector<uint8_t> b; assert(p1b.ensure(b));
+    hmac_cpp::secure_buffer<uint8_t, true> sa(std::move(a));
+    hmac_cpp::secure_buffer<uint8_t, true> sb(std::move(b));
+    assert(hmac_cpp::constant_time_equal(sa.data(), sa.size(), sb.data(), sb.size()));
+    pepper::Config c2 = c1; c2.app_salt[0] ^= 0xFF; pepper::Provider p2(c2); std::vector<uint8_t> c; assert(p2.ensure(c));
+    hmac_cpp::secure_buffer<uint8_t, true> sc(std::move(c));
+    assert(!hmac_cpp::constant_time_equal(sa.data(), sa.size(), sc.data(), sc.size()));
 }
 
 static void test_encrypted_file() {
     pepper::Config cfg; cfg.primary = pepper::StorageMode::ENCRYPTED_FILE; cfg.file_path = "pepper_test.bin"; cfg.app_salt = salt16();
     { pepper::Provider p(cfg); std::vector<uint8_t> a; assert(p.ensure(a)); }
     pepper::Provider p2(cfg); std::vector<uint8_t> b; assert(p2.ensure(b));
-    pepper::Provider p3(cfg); std::vector<uint8_t> c; assert(p3.load(c)); assert(b==c);
+    pepper::Provider p3(cfg); std::vector<uint8_t> c; assert(p3.load(c));
+    hmac_cpp::secure_buffer<uint8_t, true> sb(std::move(b));
+    hmac_cpp::secure_buffer<uint8_t, true> sc(std::move(c));
+    assert(hmac_cpp::constant_time_equal(sb.data(), sb.size(), sc.data(), sc.size()));
     std::ofstream(cfg.file_path, std::ios::binary|std::ios::trunc) << "bad";
     cfg.fallbacks.clear();
     pepper::Provider p4(cfg); std::vector<uint8_t> d; assert(!p4.load(d));

--- a/test/test_vault.cpp
+++ b/test/test_vault.cpp
@@ -11,6 +11,7 @@
 #include <hmac_cpp/hmac_utils.hpp>
 #include <hmac_cpp/encoding.hpp>
 #include <hmac_cpp/secret_string.hpp>
+#include <hmac_cpp/secure_buffer.hpp>
 #include <obfy/obfy_str.hpp>
 
 #include "json.hpp"
@@ -21,25 +22,23 @@ using namespace hmac_cpp;
 
 static std::string pepper() { return std::string(OBFY_STR("demo_pepper")); }
 
-static std::vector<uint8_t> to_bytes(const std::string& s){
-    return std::vector<uint8_t>(s.begin(), s.end());
+static std::string b64enc(const hmac_cpp::secure_buffer<uint8_t, true>& v){
+    return hmac_cpp::base64_encode(v.data(), v.size());
 }
+static hmac_cpp::secure_buffer<uint8_t, true> b64dec(const std::string& s){
+    std::vector<uint8_t> tmp; if(!hmac_cpp::base64_decode(s,tmp)) throw std::runtime_error("b64"); return hmac_cpp::secure_buffer<uint8_t, true>(std::move(tmp)); }
 
-static std::string b64enc(const std::vector<uint8_t>& v){
-    return hmac_cpp::base64_encode(v);
-}
-static std::vector<uint8_t> b64dec(const std::string& s){
-    std::vector<uint8_t> out; if(!hmac_cpp::base64_decode(s,out)) throw std::runtime_error("b64"); return out; }
-
-static std::array<uint8_t,32> derive_key(const std::string& password,
-                                         const std::vector<uint8_t>& salt,
-                                         uint32_t iters) {
-    auto pw = to_bytes(password);
-    auto pep = to_bytes(pepper());
-    auto vec = pbkdf2_with_pepper(pw, salt, pep, iters, 32);
-    std::array<uint8_t,32> key{};
-    std::copy(vec.begin(), vec.end(), key.begin());
-    return key;
+static hmac_cpp::secure_buffer<uint8_t, true> derive_key(const std::string& password,
+                                                         const hmac_cpp::secure_buffer<uint8_t, true>& salt,
+                                                         uint32_t iters) {
+    std::string pw_copy(password);
+    hmac_cpp::secure_buffer<uint8_t, true> pw(std::move(pw_copy));
+    hmac_cpp::secure_buffer<uint8_t, true> pep{std::string(pepper())};
+    auto vec = pbkdf2_with_pepper(pw.data(), pw.size(),
+                                  salt.data(), salt.size(),
+                                  pep.data(), pep.size(),
+                                  iters, 32);
+    return hmac_cpp::secure_buffer<uint8_t, true>(std::move(vec));
 }
 
 static void test_simple() {
@@ -48,15 +47,16 @@ static void test_simple() {
     const uint32_t iters = 1000;
     const std::string aad = "t";
 
-    auto salt = random_bytes(16);
+    hmac_cpp::secure_buffer<uint8_t, true> salt(random_bytes(16));
     auto key  = derive_key(master, salt, iters);
+    std::array<uint8_t,32> key_arr{}; std::copy(key.begin(), key.begin()+key_arr.size(), key_arr.begin());
     std::vector<uint8_t> aad_bytes(aad.begin(), aad.end());
-    auto enc = utils::encrypt_gcm(payload, key, aad_bytes);
+    auto enc = utils::encrypt_gcm(payload, key_arr, aad_bytes);
     std::string serialized = std::to_string(iters) + ":" +
        b64enc(salt) + ":" +
-       b64enc(std::vector<uint8_t>(enc.iv.begin(), enc.iv.end())) + ":" +
-       b64enc(std::vector<uint8_t>(enc.tag.begin(), enc.tag.end())) + ":" +
-       b64enc(enc.ciphertext);
+       b64enc(hmac_cpp::secure_buffer<uint8_t,true>(std::vector<uint8_t>(enc.iv.begin(), enc.iv.end()))) + ":" +
+       b64enc(hmac_cpp::secure_buffer<uint8_t,true>(std::vector<uint8_t>(enc.tag.begin(), enc.tag.end()))) + ":" +
+       b64enc(hmac_cpp::secure_buffer<uint8_t,true>(std::move(enc.ciphertext)));
     std::vector<std::string> parts; std::stringstream ss(serialized); std::string item;
     while (std::getline(ss, item, ':')) parts.push_back(item);
     assert(parts.size()==5);
@@ -66,71 +66,99 @@ static void test_simple() {
     auto tag2 = b64dec(parts[3]);
     auto ct2 = b64dec(parts[4]);
     auto key2 = derive_key(master, salt2, iters2);
+    std::array<uint8_t,32> key2_arr{}; std::copy(key2.begin(), key2.begin()+key2_arr.size(), key2_arr.begin());
     utils::GcmEncryptedData packet;
-    std::copy(iv2.begin(), iv2.end(), packet.iv.begin());
-    packet.ciphertext = ct2;
-    std::copy(tag2.begin(), tag2.end(), packet.tag.begin());
-    auto plain = utils::decrypt_gcm_to_string(packet, key2, aad_bytes);
-    assert(plain == payload);
+    std::copy(iv2.begin(), iv2.begin()+packet.iv.size(), packet.iv.begin());
+    packet.ciphertext = std::vector<uint8_t>(ct2.begin(), ct2.end());
+    std::copy(tag2.begin(), tag2.begin()+packet.tag.size(), packet.tag.begin());
+    auto plain = utils::decrypt_gcm_to_string(packet, key2_arr, aad_bytes);
+    hmac_cpp::secure_zero(key_arr.data(), key_arr.size());
+    hmac_cpp::secure_zero(key2_arr.data(), key2_arr.size());
+    hmac_cpp::secure_buffer<uint8_t, true> plain_buf(std::move(plain));
+    hmac_cpp::secure_buffer<uint8_t, true> payload_buf{std::string(payload)};
+    assert(hmac_cpp::constant_time_equal(plain_buf.data(), plain_buf.size(),
+                                        payload_buf.data(), payload_buf.size()));
 }
 
 struct VaultFile {
     uint32_t v = 1;
     uint32_t iters;
-    std::vector<uint8_t> salt;
-    std::vector<uint8_t> iv;
-    std::vector<uint8_t> tag;
-    std::vector<uint8_t> ct;
+    hmac_cpp::secure_buffer<uint8_t, true> salt;
+    hmac_cpp::secure_buffer<uint8_t, true> iv;
+    hmac_cpp::secure_buffer<uint8_t, true> tag;
+    hmac_cpp::secure_buffer<uint8_t, true> ct;
     std::string aad;
 };
 
 static std::string serialize_vault(const VaultFile& vf) {
     json j;
     j["v"] = vf.v;
-    j["kdf"] = {{"name","PBKDF2-HMAC-SHA256"},{"iters",vf.iters},{"salt",b64enc(vf.salt)},{"dkLen",32}};
-    j["aead"] = {{"alg","AES-256-GCM"},{"iv",b64enc(vf.iv)},{"tag",b64enc(vf.tag)}};
-    j["ciphertext"] = b64enc(vf.ct);
+    j["aead"] = "AES-256-GCM";
+    j["kdf"] = {{"prf","PBKDF2-HMAC-SHA256"},{"iters",vf.iters},{"salt",b64enc(vf.salt)}};
+    j["enc"] = {{"iv",b64enc(vf.iv)},{"ct",b64enc(vf.ct)},{"tag",b64enc(vf.tag)}};
     if(!vf.aad.empty()) j["aad"]=vf.aad;
     return j.dump();
 }
 static VaultFile parse_vault(const std::string& s) {
     auto j = json::parse(s);
     VaultFile vf; vf.v=j.at("v").get<uint32_t>();
-    auto jk=j.at("kdf"); vf.iters=jk.at("iters").get<uint32_t>(); vf.salt=b64dec(jk.at("salt").get<std::string>());
-    auto ja=j.at("aead"); vf.iv=b64dec(ja.at("iv").get<std::string>()); vf.tag=b64dec(ja.at("tag").get<std::string>());
-    vf.ct=b64dec(j.at("ciphertext").get<std::string>());
+    if(vf.v!=1) throw std::runtime_error("bad version");
+    if (j.at("aead").get<std::string>()!="AES-256-GCM") throw std::runtime_error("bad aead");
+    auto jk=j.at("kdf"); vf.iters=jk.at("iters").get<uint32_t>();
+    if(vf.iters<100000||vf.iters>1000000) throw std::runtime_error("bad iters");
+    vf.salt=b64dec(jk.at("salt").get<std::string>());
+    if(vf.salt.size()<16||vf.salt.size()>32) throw std::runtime_error("bad salt size");
+    auto je=j.at("enc"); vf.iv=b64dec(je.at("iv").get<std::string>()); if(vf.iv.size()!=12) throw std::runtime_error("bad iv size");
+    vf.ct=b64dec(je.at("ct").get<std::string>());
+    vf.tag=b64dec(je.at("tag").get<std::string>()); if(vf.tag.size()!=16) throw std::runtime_error("bad tag size");
     vf.aad=j.value("aad","");
     return vf;
 }
 static VaultFile create_vault(const std::string& master,const std::string& email,const std::string& password,uint32_t iters,const std::string& aad){
-    VaultFile vf; vf.v=1; vf.iters=iters; vf.salt=random_bytes(16); auto key=derive_key(master,vf.salt,iters); json payload={{"email",email},{"password",password}}; auto plain=to_bytes(payload.dump()); std::vector<uint8_t> aadb=to_bytes(aad); auto enc=utils::encrypt_gcm(plain,key,aadb); vf.iv.assign(enc.iv.begin(),enc.iv.end()); vf.ct=std::move(enc.ciphertext); vf.tag.assign(enc.tag.begin(),enc.tag.end()); vf.aad=aad; return vf; }
-static json open_vault(const std::string& master,const VaultFile& vf){ auto key=derive_key(master,vf.salt,vf.iters); std::array<uint8_t,12> iv{}; std::copy(vf.iv.begin(),vf.iv.end(),iv.begin()); std::array<uint8_t,16> tag{}; std::copy(vf.tag.begin(),vf.tag.end(),tag.begin()); std::vector<uint8_t> aadb=to_bytes(vf.aad); utils::GcmEncryptedData pkt{std::chrono::system_clock::now(),iv,vf.ct,tag}; auto plain=utils::decrypt_gcm_to_string(pkt,key,aadb); return json::parse(plain); }
+    VaultFile vf; vf.v=1; vf.iters=iters; vf.salt=hmac_cpp::secure_buffer<uint8_t,true>(random_bytes(16)); auto key=derive_key(master,vf.salt,iters); std::array<uint8_t,32> key_arr{}; std::copy(key.begin(),key.begin()+key_arr.size(),key_arr.begin()); json payload={{"email",email},{"password",password}}; std::string payload_str=payload.dump(); hmac_cpp::secure_buffer<uint8_t,true> plain(std::move(payload_str)); std::vector<uint8_t> aadb(aad.begin(),aad.end()); std::vector<uint8_t> plain_vec(plain.begin(),plain.end()); auto enc=utils::encrypt_gcm(plain_vec,key_arr,aadb); hmac_cpp::secure_zero(key_arr.data(),key_arr.size()); hmac_cpp::secure_zero(plain_vec.data(),plain_vec.size()); vf.iv=hmac_cpp::secure_buffer<uint8_t,true>(std::vector<uint8_t>(enc.iv.begin(),enc.iv.end())); vf.ct=hmac_cpp::secure_buffer<uint8_t,true>(std::move(enc.ciphertext)); vf.tag=hmac_cpp::secure_buffer<uint8_t,true>(std::vector<uint8_t>(enc.tag.begin(),enc.tag.end())); vf.aad=aad; return vf; }
+static json open_vault(const std::string& master,const VaultFile& vf){ auto key=derive_key(master,vf.salt,vf.iters); std::array<uint8_t,32> key_arr{}; std::copy(key.begin(),key.begin()+key_arr.size(),key_arr.begin()); std::array<uint8_t,12> iv{}; std::copy(vf.iv.begin(),vf.iv.begin()+iv.size(),iv.begin()); std::array<uint8_t,16> tag{}; std::copy(vf.tag.begin(),vf.tag.begin()+tag.size(),tag.begin()); std::vector<uint8_t> aadb(vf.aad.begin(),vf.aad.end()); std::vector<uint8_t> ct_vec(vf.ct.begin(),vf.ct.end()); utils::GcmEncryptedData pkt{std::chrono::system_clock::now(),iv,ct_vec,tag}; auto plain=utils::decrypt_gcm_to_string(pkt,key_arr,aadb); hmac_cpp::secure_zero(key_arr.data(),key_arr.size()); hmac_cpp::secure_zero(ct_vec.data(),ct_vec.size()); auto r=json::parse(plain); hmac_cpp::secure_zero(&plain[0],plain.size()); return r; }
 
-static std::string b64url_encode(const std::vector<uint8_t>& d){ auto s=b64enc(d); std::replace(s.begin(),s.end(),'+','-'); std::replace(s.begin(),s.end(),'/','_'); while(!s.empty()&&s.back()=='=') s.pop_back(); return s; }
-static std::vector<uint8_t> b64url_decode(const std::string& s){ std::string t=s; std::replace(t.begin(),t.end(),'-','+'); std::replace(t.begin(),t.end(),'_','/'); while(t.size()%4) t.push_back('='); return b64dec(t); }
+static std::string b64url_encode(const hmac_cpp::secure_buffer<uint8_t, true>& d){ auto s=b64enc(d); std::replace(s.begin(),s.end(),'+','-'); std::replace(s.begin(),s.end(),'/','_'); while(!s.empty()&&s.back()=='=') s.pop_back(); return s; }
+static hmac_cpp::secure_buffer<uint8_t, true> b64url_decode(const std::string& s){ std::string t=s; std::replace(t.begin(),t.end(),'-','+'); std::replace(t.begin(),t.end(),'_','/'); while(t.size()%4) t.push_back('='); return b64dec(t); }
 
 static void test_json(){
     const std::string master="m", email="e", pass="p";
-    auto vf=create_vault(master,email,pass,1000,"t");
+    auto vf=create_vault(master,email,pass,100000,"t");
     auto text=serialize_vault(vf);
     auto parsed=parse_vault(text);
     auto payload=open_vault(master,parsed);
-    assert(payload.at("email").get<std::string>()==email);
-    assert(payload.at("password").get<std::string>()==pass);
+    auto email_dec = payload.at("email").get<std::string>();
+    auto pass_dec = payload.at("password").get<std::string>();
+    hmac_cpp::secure_buffer<uint8_t, true> email_buf(std::move(email_dec));
+    hmac_cpp::secure_buffer<uint8_t, true> email_exp{std::string(email)};
+    assert(hmac_cpp::constant_time_equal(email_buf.data(), email_buf.size(),
+                                        email_exp.data(), email_exp.size()));
+    hmac_cpp::secure_buffer<uint8_t, true> pass_buf(std::move(pass_dec));
+    hmac_cpp::secure_buffer<uint8_t, true> pass_exp{std::string(pass)};
+    assert(hmac_cpp::constant_time_equal(pass_buf.data(), pass_buf.size(),
+                                        pass_exp.data(), pass_exp.size()));
 }
 
 static void test_jwr(){
     const std::string master="m", email="e", pass="p";
-    auto vf=create_vault(master,email,pass,1000,"t");
+    auto vf=create_vault(master,email,pass,100000,"t");
     std::string header=json({{"typ","JWR"}}).dump();
     std::string body=serialize_vault(vf);
-    std::string token=b64url_encode(to_bytes(header))+"."+b64url_encode(to_bytes(body));
+    std::string token=b64url_encode(hmac_cpp::secure_buffer<uint8_t,true>(std::string(header)))+"."+b64url_encode(hmac_cpp::secure_buffer<uint8_t,true>(std::string(body)));
     auto pos=token.find('.'); assert(pos!=std::string::npos);
     auto body_bytes=b64url_decode(token.substr(pos+1));
     auto parsed=parse_vault(std::string(body_bytes.begin(),body_bytes.end()));
     auto payload=open_vault(master,parsed);
-    assert(payload.at("email").get<std::string>()==email);
-    assert(payload.at("password").get<std::string>()==pass);
+    auto email_dec = payload.at("email").get<std::string>();
+    auto pass_dec = payload.at("password").get<std::string>();
+    hmac_cpp::secure_buffer<uint8_t, true> email_buf(std::move(email_dec));
+    hmac_cpp::secure_buffer<uint8_t, true> email_exp{std::string(email)};
+    assert(hmac_cpp::constant_time_equal(email_buf.data(), email_buf.size(),
+                                        email_exp.data(), email_exp.size()));
+    hmac_cpp::secure_buffer<uint8_t, true> pass_buf(std::move(pass_dec));
+    hmac_cpp::secure_buffer<uint8_t, true> pass_exp{std::string(pass)};
+    assert(hmac_cpp::constant_time_equal(pass_buf.data(), pass_buf.size(),
+                                        pass_exp.data(), pass_exp.size()));
 }
 
 int main(){


### PR DESCRIPTION
## Summary
- adopt hmac_cpp secure_buffer for salts, IV, tags and ciphertext
- serialize vault files with versioned AES-GCM JSON layout
- ensure plaintext and key material are zeroized after use
- harden JWR and simple demos with secure buffers and one-shot obfuscation
- validate vault version and PBKDF2 iteration range in parsers
- compare secrets in tests using constant-time equality
- write vault files atomically with restrictive permissions

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bf967ecffc832ca25cf98e4c0d64bc