### PR TITLE
refactor(examples): use error codes instead of exceptions

### DIFF
--- a/examples/json_vault.cpp
+++ b/examples/json_vault.cpp
@@ -1,7 +1,8 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include <stdexcept>
+#include <variant>
+#include <functional>
 #include <vector>
 #include <string>
 #include <array>
@@ -22,6 +23,20 @@
 #include "file_io.hpp"
 using json = nlohmann::json;
 
+enum class VaultError {
+    ERR_FORMAT = 1,
+    ERR_KDF_PARAM,
+    ERR_GCM_TAG,
+    ERR_RNG
+};
+
+template <typename T, typename E>
+using expected = std::variant<T, E>;
+
+static void log_error(VaultError e) {
+    std::cerr << "ERR: " << static_cast<int>(e) << "\n";
+}
+
 struct VaultFile {
     uint32_t v = 1;
     uint32_t iters;
@@ -32,9 +47,10 @@ struct VaultFile {
     std::string aad;
 };
 
-static hmac_cpp::secure_buffer<uint8_t, true> b64dec(const std::string& s) {
+static expected<hmac_cpp::secure_buffer<uint8_t, true>, VaultError>
+b64dec(const std::string& s) {
     std::vector<uint8_t> tmp;
-    if (!hmac_cpp::base64_decode(s, tmp)) throw std::runtime_error("b64");
+    if (!hmac_cpp::base64_decode(s, tmp)) return VaultError::ERR_FORMAT;
     return hmac_cpp::secure_buffer<uint8_t, true>(std::move(tmp));
 }
 
@@ -64,14 +80,16 @@ static pepper::Provider& provider() {
     return *prov;
 }
 
-static const hmac_cpp::secure_buffer<uint8_t, true>& app_pepper() {
+static expected<std::reference_wrapper<const hmac_cpp::secure_buffer<uint8_t, true>>,
+                VaultError>
+app_pepper() {
     static hmac_cpp::secure_buffer<uint8_t, true> p;
     if (p.size()==0) {
         std::vector<uint8_t> tmp;
-        if (!provider().ensure(tmp)) throw std::runtime_error("pepper");
+        if (!provider().ensure(tmp)) return VaultError::ERR_RNG;
         p = hmac_cpp::secure_buffer<uint8_t, true>(std::move(tmp));
     }
-    return p;
+    return std::cref(p);
 }
 
 static std::string serialize_vault(const VaultFile& vf) {
@@ -82,58 +100,81 @@ static std::string serialize_vault(const VaultFile& vf) {
     return j.dump(2);
 }
 
-static VaultFile parse_vault(const std::string& s) {
-    auto j = json::parse(s);
-    VaultFile vf;
-    vf.v = j.at("v").get<uint32_t>();
-    if (vf.v != 1) throw std::runtime_error("bad version");
-    auto jk = j.at("kdf");
-    if (jk.at("alg").get<std::string>() != "pbkdf2-hmac-sha256")
-        throw std::runtime_error("bad kdf alg");
-    vf.iters = jk.at("iters").get<uint32_t>();
-    if (vf.iters < 100000 || vf.iters > 1000000)
-        throw std::runtime_error("bad iters");
-    vf.salt  = b64dec(jk.at("salt").get<std::string>());
-    if (vf.salt.size() < 16 || vf.salt.size() > 32)
-        throw std::runtime_error("bad salt size");
-    auto ja = j.at("aead");
-    if (ja.at("alg").get<std::string>() != "aes-256-gcm")
-        throw std::runtime_error("bad aead alg");
-    vf.iv   = b64dec(ja.at("iv").get<std::string>());
-    if (vf.iv.size() != 12) throw std::runtime_error("bad iv size");
-    vf.ct   = b64dec(ja.at("ct").get<std::string>());
-    vf.tag  = b64dec(ja.at("tag").get<std::string>());
-    if (vf.tag.size() != 16) throw std::runtime_error("bad tag size");
-    vf.aad  = ja.value("aad", "");
-    return vf;
+static expected<VaultFile, VaultError> parse_vault(const std::string& s) {
+    try {
+        auto j = json::parse(s);
+        VaultFile vf;
+        vf.v = j.at("v").get<uint32_t>();
+        if (vf.v != 1) return VaultError::ERR_FORMAT;
+        auto jk = j.at("kdf");
+        if (jk.at("alg").get<std::string>() != "pbkdf2-hmac-sha256")
+            return VaultError::ERR_KDF_PARAM;
+        vf.iters = jk.at("iters").get<uint32_t>();
+        if (vf.iters < 100000 || vf.iters > 1000000)
+            return VaultError::ERR_KDF_PARAM;
+        auto salt_res = b64dec(jk.at("salt").get<std::string>());
+        if (std::holds_alternative<VaultError>(salt_res))
+            return std::get<VaultError>(salt_res);
+        vf.salt = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(salt_res));
+        if (vf.salt.size() < 16 || vf.salt.size() > 32)
+            return VaultError::ERR_KDF_PARAM;
+        auto ja = j.at("aead");
+        if (ja.at("alg").get<std::string>() != "aes-256-gcm")
+            return VaultError::ERR_FORMAT;
+        auto iv_res = b64dec(ja.at("iv").get<std::string>());
+        if (std::holds_alternative<VaultError>(iv_res))
+            return std::get<VaultError>(iv_res);
+        vf.iv = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(iv_res));
+        if (vf.iv.size() != 12) return VaultError::ERR_FORMAT;
+        auto ct_res = b64dec(ja.at("ct").get<std::string>());
+        if (std::holds_alternative<VaultError>(ct_res))
+            return std::get<VaultError>(ct_res);
+        vf.ct = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(ct_res));
+        auto tag_res = b64dec(ja.at("tag").get<std::string>());
+        if (std::holds_alternative<VaultError>(tag_res))
+            return std::get<VaultError>(tag_res);
+        vf.tag = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(tag_res));
+        if (vf.tag.size() != 16) return VaultError::ERR_GCM_TAG;
+        vf.aad  = ja.value("aad", "");
+        return vf;
+    } catch (...) {
+        return VaultError::ERR_FORMAT;
+    }
 }
 
-static hmac_cpp::secure_buffer<uint8_t, true> derive_key(
-        const std::string& password,
-        const hmac_cpp::secure_buffer<uint8_t, true>& salt,
-        uint32_t iters) {
+static expected<hmac_cpp::secure_buffer<uint8_t, true>, VaultError>
+derive_key(const std::string& password,
+           const hmac_cpp::secure_buffer<uint8_t, true>& salt,
+           uint32_t iters) {
     std::string pw_copy(password);
     hmac_cpp::secure_buffer<uint8_t, true> pw(std::move(pw_copy));
+    auto pep_res = app_pepper();
+    if (std::holds_alternative<VaultError>(pep_res))
+        return std::get<VaultError>(pep_res);
+    const auto& p = std::get<std::reference_wrapper<const hmac_cpp::secure_buffer<uint8_t, true>>>(pep_res).get();
     auto vec = hmac_cpp::pbkdf2_with_pepper(pw.data(), pw.size(),
                                             salt.data(), salt.size(),
-                                            app_pepper().data(), app_pepper().size(),
+                                            p.data(), p.size(),
                                             iters, 32);
     return hmac_cpp::secure_buffer<uint8_t, true>(std::move(vec));
 }
 
-static VaultFile create_vault(const std::string& master_password,
-                              const std::string& email,
-                              const std::string& password,
-                              uint32_t iters = 300000,
-                              const std::string& aad = "app=demo;v=1")
-{
+static expected<VaultFile, VaultError>
+create_vault(const std::string& master_password,
+             const std::string& email,
+             const std::string& password,
+             uint32_t iters = 300000,
+             const std::string& aad = "app=demo;v=1") {
     VaultFile vf;
     vf.v = 1;
     vf.iters = iters;
     auto salt_vec = hmac_cpp::random_bytes(16);
-    if (salt_vec.size() != 16) throw std::runtime_error("rng");
+    if (salt_vec.size() != 16) return VaultError::ERR_RNG;
     vf.salt = hmac_cpp::secure_buffer<uint8_t, true>(std::move(salt_vec));
-    auto key = derive_key(master_password, vf.salt, iters);
+    auto key_res = derive_key(master_password, vf.salt, iters);
+    if (std::holds_alternative<VaultError>(key_res))
+        return std::get<VaultError>(key_res);
+    auto key = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(key_res));
     std::array<uint8_t,32> key_arr{};
     std::copy(key.begin(), key.begin()+key_arr.size(), key_arr.begin());
 
@@ -153,8 +194,12 @@ static VaultFile create_vault(const std::string& master_password,
     return vf;
 }
 
-static json open_vault(const std::string& master_password, const VaultFile& vf) {
-    auto key = derive_key(master_password, vf.salt, vf.iters);
+static expected<json, VaultError>
+open_vault(const std::string& master_password, const VaultFile& vf) {
+    auto key_res = derive_key(master_password, vf.salt, vf.iters);
+    if (std::holds_alternative<VaultError>(key_res))
+        return std::get<VaultError>(key_res);
+    auto key = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(key_res));
     std::array<uint8_t,32> key_arr{};
     std::copy(key.begin(), key.begin()+key_arr.size(), key_arr.begin());
     std::array<uint8_t,12> iv{};
@@ -165,12 +210,24 @@ static json open_vault(const std::string& master_password, const VaultFile& vf) 
     std::vector<uint8_t> aad_bytes(vf.aad.begin(), vf.aad.end());
     std::vector<uint8_t> ct_vec(vf.ct.begin(), vf.ct.end());
     aes_cpp::utils::GcmEncryptedData pkt{std::chrono::system_clock::now(), iv, ct_vec, tag};
-    auto plain = aes_cpp::utils::decrypt_gcm_to_string(pkt, key_arr, aad_bytes);
+    std::string plain;
+    try {
+        plain = aes_cpp::utils::decrypt_gcm_to_string(pkt, key_arr, aad_bytes);
+    } catch (...) {
+        hmac_cpp::secure_zero(key_arr.data(), key_arr.size());
+        hmac_cpp::secure_zero(ct_vec.data(), ct_vec.size());
+        return VaultError::ERR_GCM_TAG;
+    }
     hmac_cpp::secure_zero(key_arr.data(), key_arr.size());
     hmac_cpp::secure_zero(ct_vec.data(), ct_vec.size());
-    auto j = json::parse(plain);
-    hmac_cpp::secure_zero(&plain[0], plain.size());
-    return j;
+    try {
+        auto j = json::parse(plain);
+        hmac_cpp::secure_zero(&plain[0], plain.size());
+        return j;
+    } catch (...) {
+        hmac_cpp::secure_zero(&plain[0], plain.size());
+        return VaultError::ERR_FORMAT;
+    }
 }
 
 int main(int argc, char** argv) {
@@ -179,35 +236,46 @@ int main(int argc, char** argv) {
         if (arg.rfind("--pepper=", 0) == 0) g_pepper_mode = arg.substr(9);
         else if (arg == "--deny-fallback") g_deny_fallback = true;
     }
-    try {
-        const std::string master = "correct horse battery staple";
-        const std::string email   = "user@example.com";
-        const std::string pass    = "s3cr3t!";
 
-        auto aad_tmp = OBFY_BYTES_ONCE("app://secrets/blob/v1");
-        std::string aad(reinterpret_cast<const char*>(aad_tmp.data()), aad_tmp.size());
-        auto vf = create_vault(master, email, pass, 300000, aad);
-        auto text = serialize_vault(vf);
-        demo::atomic_write_file("vault.json", text);
-        std::cout << "Saved JSON:\n" << text << "\n";
+    const std::string master = "correct horse battery staple";
+    const std::string email   = "user@example.com";
+    const std::string pass    = "s3cr3t!";
 
-        std::ifstream ifs("vault.json");
-        std::stringstream buffer; buffer << ifs.rdbuf();
-        std::string blob = buffer.str();
-        VaultFile vf2 = parse_vault(blob);
-        hmac_cpp::secure_zero(&blob[0], blob.size());
-        blob.clear();
-        auto payload  = open_vault(master, vf2);
-        hmac_cpp::secret_string em(payload.at("email").get<std::string>());
-        hmac_cpp::secret_string pw(payload.at("password").get<std::string>());
-        std::cout << "Decrypted email: "    << em.reveal_copy() << "\n";
-        std::cout << "Decrypted password: " << pw.reveal_copy() << "\n";
-        em.clear();
-        pw.clear();
-    } catch (const std::exception& e) {
-        std::cerr << "ERR: " << e.what() << "\n";
+    auto aad_tmp = OBFY_BYTES_ONCE("app://secrets/blob/v1");
+    std::string aad(reinterpret_cast<const char*>(aad_tmp.data()), aad_tmp.size());
+    auto vf_res = create_vault(master, email, pass, 300000, aad);
+    if (std::holds_alternative<VaultError>(vf_res)) {
+        log_error(std::get<VaultError>(vf_res));
         return 1;
     }
+    auto vf = std::get<VaultFile>(std::move(vf_res));
+    auto text = serialize_vault(vf);
+    demo::atomic_write_file("vault.json", text);
+    std::cout << "Saved JSON:\n" << text << "\n";
+
+    std::ifstream ifs("vault.json");
+    std::stringstream buffer; buffer << ifs.rdbuf();
+    std::string blob = buffer.str();
+    auto pv = parse_vault(blob);
+    hmac_cpp::secure_zero(&blob[0], blob.size());
+    blob.clear();
+    if (std::holds_alternative<VaultError>(pv)) {
+        log_error(std::get<VaultError>(pv));
+        return 1;
+    }
+    VaultFile vf2 = std::get<VaultFile>(std::move(pv));
+    auto payload_res = open_vault(master, vf2);
+    if (std::holds_alternative<VaultError>(payload_res)) {
+        log_error(std::get<VaultError>(payload_res));
+        return 1;
+    }
+    auto payload = std::get<json>(std::move(payload_res));
+    hmac_cpp::secret_string em(payload.at("email").get<std::string>());
+    hmac_cpp::secret_string pw(payload.at("password").get<std::string>());
+    std::cout << "Decrypted email: "    << em.reveal_copy() << "\n";
+    std::cout << "Decrypted password: " << pw.reveal_copy() << "\n";
+    em.clear();
+    pw.clear();
     return 0;
 }
 

--- a/examples/jwr_vault.cpp
+++ b/examples/jwr_vault.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <fstream>
-#include <stdexcept>
+#include <variant>
+#include <functional>
 #include <vector>
 #include <string>
 #include <array>
@@ -20,6 +21,20 @@
 #include "json.hpp"
 #include "file_io.hpp"
 using json = nlohmann::json;
+
+enum class VaultError {
+    ERR_FORMAT = 1,
+    ERR_KDF_PARAM,
+    ERR_GCM_TAG,
+    ERR_RNG
+};
+
+template <typename T, typename E>
+using expected = std::variant<T, E>;
+
+static void log_error(VaultError e) {
+    std::cerr << "ERR: " << static_cast<int>(e) << "\n";
+}
 
 struct VaultFile {
     uint32_t v = 1;
@@ -41,13 +56,16 @@ static std::string to_string(const std::vector<uint8_t>& v) {
 static std::string b64enc(const hmac_cpp::secure_buffer<uint8_t, true>& v) {
     return hmac_cpp::base64_encode(v.data(), v.size());
 }
-static hmac_cpp::secure_buffer<uint8_t, true> b64dec(const std::string& s) {
+static expected<hmac_cpp::secure_buffer<uint8_t, true>, VaultError>
+b64dec(const std::string& s) {
     std::vector<uint8_t> tmp;
-    if (!hmac_cpp::base64_decode(s, tmp)) throw std::runtime_error("b64");
+    if (!hmac_cpp::base64_decode(s, tmp)) return VaultError::ERR_FORMAT;
     return hmac_cpp::secure_buffer<uint8_t, true>(std::move(tmp));
 }
 
-static const hmac_cpp::secure_buffer<uint8_t, true>& app_pepper() {
+static expected<std::reference_wrapper<const hmac_cpp::secure_buffer<uint8_t, true>>,
+                VaultError>
+app_pepper() {
     static hmac_cpp::secure_buffer<uint8_t, true> p;
     if (p.size() == 0) {
         pepper::Config cfg;
@@ -61,10 +79,10 @@ static const hmac_cpp::secure_buffer<uint8_t, true>& app_pepper() {
         hmac_cpp::secure_zero(s.data(), s.size());
         pepper::Provider prov(cfg);
         std::vector<uint8_t> tmp;
-        if (!prov.ensure(tmp)) throw std::runtime_error("pepper");
+        if (!prov.ensure(tmp)) return VaultError::ERR_RNG;
         p = hmac_cpp::secure_buffer<uint8_t, true>(std::move(tmp));
     }
-    return p;
+    return std::cref(p);
 }
 
 static std::string serialize_vault(const VaultFile& vf) {
@@ -86,50 +104,75 @@ static std::string serialize_vault(const VaultFile& vf) {
     return j.dump();
 }
 
-static VaultFile parse_vault(const std::string& s) {
-    auto j = json::parse(s);
-    VaultFile vf;
-    vf.v = j.at("v").get<uint32_t>();
-    if (vf.v != 1) throw std::runtime_error("bad version");
-    auto jk = j.at("kdf");
-    vf.iters = jk.at("iters").get<uint32_t>();
-    if (vf.iters < 100000 || vf.iters > 1000000)
-        throw std::runtime_error("bad iters");
-    vf.salt  = b64dec(jk.at("salt").get<std::string>());
+static expected<VaultFile, VaultError> parse_vault(const std::string& s) {
+    try {
+        auto j = json::parse(s);
+        VaultFile vf;
+        vf.v = j.at("v").get<uint32_t>();
+        if (vf.v != 1) return VaultError::ERR_FORMAT;
+        auto jk = j.at("kdf");
+        vf.iters = jk.at("iters").get<uint32_t>();
+        if (vf.iters < 100000 || vf.iters > 1000000)
+            return VaultError::ERR_KDF_PARAM;
+        auto salt_res = b64dec(jk.at("salt").get<std::string>());
+        if (std::holds_alternative<VaultError>(salt_res))
+            return std::get<VaultError>(salt_res);
+        vf.salt = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(salt_res));
 
-    auto ja = j.at("aead");
-    vf.iv   = b64dec(ja.at("iv").get<std::string>());
-    vf.tag  = b64dec(ja.at("tag").get<std::string>());
+        auto ja = j.at("aead");
+        auto iv_res = b64dec(ja.at("iv").get<std::string>());
+        if (std::holds_alternative<VaultError>(iv_res))
+            return std::get<VaultError>(iv_res);
+        vf.iv   = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(iv_res));
+        auto tag_res = b64dec(ja.at("tag").get<std::string>());
+        if (std::holds_alternative<VaultError>(tag_res))
+            return std::get<VaultError>(tag_res);
+        vf.tag  = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(tag_res));
 
-    vf.ct   = b64dec(j.at("ciphertext").get<std::string>());
-    vf.aad  = j.value("aad", "");
-    return vf;
+        auto ct_res = b64dec(j.at("ciphertext").get<std::string>());
+        if (std::holds_alternative<VaultError>(ct_res))
+            return std::get<VaultError>(ct_res);
+        vf.ct   = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(ct_res));
+        vf.aad  = j.value("aad", "");
+        return vf;
+    } catch (...) {
+        return VaultError::ERR_FORMAT;
+    }
 }
 
-static hmac_cpp::secure_buffer<uint8_t, true> derive_key(
-        const std::string& password,
-        const hmac_cpp::secure_buffer<uint8_t, true>& salt,
-        uint32_t iters) {
+static expected<hmac_cpp::secure_buffer<uint8_t, true>, VaultError>
+derive_key(const std::string& password,
+           const hmac_cpp::secure_buffer<uint8_t, true>& salt,
+           uint32_t iters) {
     std::string pw_copy(password);
     hmac_cpp::secure_buffer<uint8_t, true> pw(std::move(pw_copy));
+    auto pep_res = app_pepper();
+    if (std::holds_alternative<VaultError>(pep_res))
+        return std::get<VaultError>(pep_res);
+    const auto& p = std::get<std::reference_wrapper<const hmac_cpp::secure_buffer<uint8_t, true>>>(pep_res).get();
     auto vec = hmac_cpp::pbkdf2_with_pepper(pw.data(), pw.size(),
                                             salt.data(), salt.size(),
-                                            app_pepper().data(), app_pepper().size(),
+                                            p.data(), p.size(),
                                             iters, 32);
     return hmac_cpp::secure_buffer<uint8_t, true>(std::move(vec));
 }
 
-static VaultFile create_vault(const std::string& master_password,
-                              const std::string& email,
-                              const std::string& password,
-                              uint32_t iters = 300000,
-                              const std::string& aad = "app=demo;v=1")
-{
+static expected<VaultFile, VaultError>
+create_vault(const std::string& master_password,
+             const std::string& email,
+             const std::string& password,
+             uint32_t iters = 300000,
+             const std::string& aad = "app=demo;v=1") {
     VaultFile vf;
     vf.v = 1;
     vf.iters = iters;
-    vf.salt = hmac_cpp::secure_buffer<uint8_t, true>(hmac_cpp::random_bytes(16));
-    auto key = derive_key(master_password, vf.salt, iters);
+    auto salt_vec = hmac_cpp::random_bytes(16);
+    if (salt_vec.size() != 16) return VaultError::ERR_RNG;
+    vf.salt = hmac_cpp::secure_buffer<uint8_t, true>(std::move(salt_vec));
+    auto key_res = derive_key(master_password, vf.salt, iters);
+    if (std::holds_alternative<VaultError>(key_res))
+        return std::get<VaultError>(key_res);
+    auto key = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(key_res));
     std::array<uint8_t,32> key_arr{};
     std::copy(key.begin(), key.begin()+key_arr.size(), key_arr.begin());
 
@@ -149,26 +192,42 @@ static VaultFile create_vault(const std::string& master_password,
     return vf;
 }
 
-static json open_vault(const std::string& master_password, const VaultFile& vf) {
-    auto key = derive_key(master_password, vf.salt, vf.iters);
+static expected<json, VaultError>
+open_vault(const std::string& master_password, const VaultFile& vf) {
+    auto key_res = derive_key(master_password, vf.salt, vf.iters);
+    if (std::holds_alternative<VaultError>(key_res))
+        return std::get<VaultError>(key_res);
+    auto key = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(key_res));
     std::array<uint8_t,32> key_arr{};
     std::copy(key.begin(), key.begin()+key_arr.size(), key_arr.begin());
     std::array<uint8_t,12> iv{};
-    if (vf.iv.size()!=iv.size()) throw std::runtime_error("bad iv size");
+    if (vf.iv.size()!=iv.size()) return VaultError::ERR_FORMAT;
     std::copy(vf.iv.begin(), vf.iv.begin()+iv.size(), iv.begin());
     std::array<uint8_t,16> tag{};
-    if (vf.tag.size()!=tag.size()) throw std::runtime_error("bad tag size");
+    if (vf.tag.size()!=tag.size()) return VaultError::ERR_GCM_TAG;
     std::copy(vf.tag.begin(), vf.tag.begin()+tag.size(), tag.begin());
 
     std::vector<uint8_t> aad_bytes = to_bytes(vf.aad);
     std::vector<uint8_t> ct_vec(vf.ct.begin(), vf.ct.end());
     aes_cpp::utils::GcmEncryptedData pkt{std::chrono::system_clock::now(), iv, ct_vec, tag};
-    auto plain = aes_cpp::utils::decrypt_gcm_to_string(pkt, key_arr, aad_bytes);
+    std::string plain;
+    try {
+        plain = aes_cpp::utils::decrypt_gcm_to_string(pkt, key_arr, aad_bytes);
+    } catch (...) {
+        hmac_cpp::secure_zero(key_arr.data(), key_arr.size());
+        hmac_cpp::secure_zero(ct_vec.data(), ct_vec.size());
+        return VaultError::ERR_GCM_TAG;
+    }
     hmac_cpp::secure_zero(key_arr.data(), key_arr.size());
     hmac_cpp::secure_zero(ct_vec.data(), ct_vec.size());
-    auto j = json::parse(plain);
-    hmac_cpp::secure_zero(&plain[0], plain.size());
-    return j;
+    try {
+        auto j = json::parse(plain);
+        hmac_cpp::secure_zero(&plain[0], plain.size());
+        return j;
+    } catch (...) {
+        hmac_cpp::secure_zero(&plain[0], plain.size());
+        return VaultError::ERR_FORMAT;
+    }
 }
 
 static std::string b64url_encode(const std::vector<uint8_t>& data) {
@@ -179,21 +238,26 @@ static std::string b64url_encode(const std::vector<uint8_t>& data) {
     return s;
 }
 
-static hmac_cpp::secure_buffer<uint8_t, true> b64url_decode(const std::string& s) {
+static expected<hmac_cpp::secure_buffer<uint8_t, true>, VaultError>
+b64url_decode(const std::string& s) {
     std::string t = s;
     std::replace(t.begin(), t.end(), '-', '+');
     std::replace(t.begin(), t.end(), '_', '/');
     while (t.size() % 4) t.push_back('=');
     std::vector<uint8_t> out;
-    if (!hmac_cpp::base64_decode(t, out)) throw std::runtime_error("b64");
+    if (!hmac_cpp::base64_decode(t, out)) return VaultError::ERR_FORMAT;
     hmac_cpp::secure_zero(&t[0], t.size());
     return hmac_cpp::secure_buffer<uint8_t, true>(std::move(out));
 }
 
-static std::string create_token(const std::string& master,
-                                const std::string& email,
-                                const std::string& password) {
-    auto vf = create_vault(master, email, password);
+static expected<std::string, VaultError>
+create_token(const std::string& master,
+             const std::string& email,
+             const std::string& password) {
+    auto vf_res = create_vault(master, email, password);
+    if (std::holds_alternative<VaultError>(vf_res))
+        return std::get<VaultError>(vf_res);
+    auto vf = std::get<VaultFile>(std::move(vf_res));
     json header = {
         {"typ","JWR"},
         {"alg","AES-256-GCM"},
@@ -207,39 +271,51 @@ static std::string create_token(const std::string& master,
     return token;
 }
 
-static json open_token(const std::string& master, const std::string& token) {
+static expected<json, VaultError>
+open_token(const std::string& master, const std::string& token) {
     auto pos = token.find('.');
-    if (pos == std::string::npos) throw std::runtime_error("bad token");
+    if (pos == std::string::npos) return VaultError::ERR_FORMAT;
     std::string body_b64 = token.substr(pos+1);
-    auto body_bytes = b64url_decode(body_b64);
-    VaultFile vf = parse_vault(std::string(body_bytes.begin(), body_bytes.end()));
+    auto body_bytes_res = b64url_decode(body_b64);
+    if (std::holds_alternative<VaultError>(body_bytes_res))
+        return std::get<VaultError>(body_bytes_res);
+    auto body_bytes = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(body_bytes_res));
+    auto vf_res = parse_vault(std::string(body_bytes.begin(), body_bytes.end()));
     hmac_cpp::secure_zero(body_bytes.data(), body_bytes.size());
-    return open_vault(master, vf);
+    if (std::holds_alternative<VaultError>(vf_res))
+        return std::get<VaultError>(vf_res);
+    auto payload = open_vault(master, std::get<VaultFile>(std::move(vf_res)));
+    return payload;
 }
 
 int main() {
-    try {
-        const std::string master = "correct horse battery staple";
-        const std::string email   = "user@example.com";
-        const std::string pass    = "s3cr3t!";
+    const std::string master = "correct horse battery staple";
+    const std::string email   = "user@example.com";
+    const std::string pass    = "s3cr3t!";
 
-        auto token = create_token(master, email, pass);
-        demo::atomic_write_file("vault.jwr", token);
-        std::cout << "Token: " << token << "\n";
-
-        std::string read_token;
-        std::ifstream("vault.jwr") >> read_token;
-        auto payload = open_token(master, read_token);
-        hmac_cpp::secret_string em(payload.at("email").get<std::string>());
-        hmac_cpp::secret_string pw(payload.at("password").get<std::string>());
-        std::cout << "Decrypted email: "    << em.reveal_copy() << "\n";
-        std::cout << "Decrypted password: " << pw.reveal_copy() << "\n";
-        em.clear();
-        pw.clear();
-    } catch (const std::exception& e) {
-        std::cerr << "ERR: " << e.what() << "\n";
+    auto token_res = create_token(master, email, pass);
+    if (std::holds_alternative<VaultError>(token_res)) {
+        log_error(std::get<VaultError>(token_res));
         return 1;
     }
+    auto token = std::get<std::string>(std::move(token_res));
+    demo::atomic_write_file("vault.jwr", token);
+    std::cout << "Token: " << token << "\n";
+
+    std::string read_token;
+    std::ifstream("vault.jwr") >> read_token;
+    auto payload_res = open_token(master, read_token);
+    if (std::holds_alternative<VaultError>(payload_res)) {
+        log_error(std::get<VaultError>(payload_res));
+        return 1;
+    }
+    auto payload = std::get<json>(std::move(payload_res));
+    hmac_cpp::secret_string em(payload.at("email").get<std::string>());
+    hmac_cpp::secret_string pw(payload.at("password").get<std::string>());
+    std::cout << "Decrypted email: "    << em.reveal_copy() << "\n";
+    std::cout << "Decrypted password: " << pw.reveal_copy() << "\n";
+    em.clear();
+    pw.clear();
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- introduce `VaultError` enum and switch example vault flows to `expected`-based error handling
- log only error codes without user input

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(fails: pepper_tests segfault)*

------
https://chatgpt.com/codex/tasks/task_e_68c065361180832cb093a2dd299328f4