### PR TITLE
test: validate decrypt_gcm failure on tag tampering

### DIFF
--- a/test/test_vault.cpp
+++ b/test/test_vault.cpp
@@ -76,9 +76,9 @@ static void test_simple() {
     packet.tag[0] ^= 1;
     bool failed = false;
     try {
-        auto fail_plain = utils::decrypt_gcm_to_string(packet, key2_arr, aad_bytes);
+        auto fail_plain = utils::decrypt_gcm(packet, key2_arr, aad_bytes);
         if (!fail_plain.empty()) {
-            hmac_cpp::secure_zero(&fail_plain[0], fail_plain.size());
+            hmac_cpp::secure_zero(fail_plain.data(), fail_plain.size());
         }
     } catch (const std::exception&) {
         failed = true;


### PR DESCRIPTION
## Summary
- ensure vault test mutates GCM tag and checks decrypt_gcm failure

## Testing
- `ctest --output-on-failure` *(fails: pepper_tests segfault)*
- `ctest -R vault_tests --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c0733b1c54832cbb6d1df71c679d79