### PR TITLE
Zero secrets after saving in examples

### DIFF
--- a/examples/json_vault.cpp
+++ b/examples/json_vault.cpp
@@ -252,6 +252,8 @@ int main(int argc, char** argv) {
     auto text = serialize_vault(vf);
     demo::atomic_write_file("vault.json", text);
     std::cout << "Saved JSON:\n" << text << "\n";
+    hmac_cpp::secure_zero(&text[0], text.size());
+    text.clear();
 
     std::ifstream ifs("vault.json");
     std::stringstream buffer; buffer << ifs.rdbuf();

--- a/examples/jwr_vault.cpp
+++ b/examples/jwr_vault.cpp
@@ -316,6 +316,8 @@ int main() {
     auto token = std::get<std::string>(std::move(token_res));
     demo::atomic_write_file("vault.jwr", token);
     std::cout << "Token: " << token << "\n";
+    hmac_cpp::secure_zero(&token[0], token.size());
+    token.clear();
 
     std::string read_token;
     std::ifstream("vault.jwr") >> read_token;


### PR DESCRIPTION
## Summary
- securely erase serialized vault text after saving
- securely erase generated token after saving

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` *(fails: pepper_tests segfault)*

------
https://chatgpt.com/codex/tasks/task_e_68c073c082c8832ca2ece7c3d9b2b4fd