### PR TITLE
docs(readme): add threat model and pepper matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # app-secrets-vault-example
 A minimal C++11 secrets vault for apps using PBKDF2 (from hmac-cpp) and AES-GCM (from aes-cpp). Stores email/password in JSON with Base64 fields {ver,iters,salt,iv,ct,tag}; optional code obfuscation via obfy.
 
+## Threat Model
+- Secrets reside only on the device, so an attacker may have offline access.
+- There is no server-side component; all protection relies on local storage.
+- Obfuscation merely slows reverse engineering and does not replace cryptography.
+
 ## Pepper provider example
 
 ```cpp
@@ -18,3 +23,13 @@ if (!prov.ensure(pepper32)) {
 }
 // pepper32 now holds a 32-byte pepper derived or stored via the configured backends.
 ```
+
+## Pepper mode matrix
+
+| `--pepper` value | Uses OS key store | Default fallbacks |
+| --- | --- | --- |
+| `keystore` (default) | ✅ | machine-bound, encrypted file |
+| `derived` | ❌ | machine-bound, encrypted file |
+| `file` | ❌ | machine-bound, encrypted file |
+
+Use `--deny-fallback` to disable the fallback list and require only the selected primary store.


### PR DESCRIPTION
## Summary
- add Threat Model section
- document pepper options matrix with `--pepper`/`--deny-fallback`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(fails: pepper_tests SEGFAULT)*

------
https://chatgpt.com/codex/tasks/task_e_68c08d3a3430832cb6162bca3c038287