### PR TITLE
feat(examples): add vault helpers

### DIFF
--- a/examples/pepper/pepper_provider.cpp
+++ b/examples/pepper/pepper_provider.cpp
@@ -5,16 +5,8 @@
 
 #include <hmac_cpp/hmac_utils.hpp>
 #include <obfy/obfy_str.hpp>
-#include <obfy/obfy_call.hpp>
 
 namespace pepper {
-
-    // Wrapper for obfuscated branching; default initialization keeps MSVC happy
-    struct ModeCase {
-        StorageMode value;
-        ModeCase(StorageMode v = StorageMode::OS_KEYCHAIN) : value(v) {}
-        bool operator==(const ModeCase& other) const { return value == other.value; }
-    };
 
     struct Provider::Impl {
         Config cfg;
@@ -38,63 +30,65 @@ namespace pepper {
     }
     
     bool Provider::load(std::vector<uint8_t>& out) {
-        OBFY_BEGIN_CODE
         std::vector<StorageMode> chain = {pimpl_->cfg.primary};
         chain.insert(chain.end(), pimpl_->cfg.fallbacks.begin(), pimpl_->cfg.fallbacks.end());
         for (auto mode : chain) {
-            ModeCase current(mode);
-            OBFY_CASE(current)
-                OBFY_WHEN(ModeCase{StorageMode::OS_KEYCHAIN}) OBFY_DO
-                    OBFY_IF(os_keychain::available())
-                        if (OBFY_CALL(os_keychain::load, pimpl_->cfg.key_id, out)) OBFY_RETURN(true);
-                    OBFY_ENDIF
-                    OBFY_BREAK
-                OBFY_DONE
-                OBFY_WHEN(ModeCase{StorageMode::MACHINE_BOUND}) OBFY_DO
-                    if (derive_machine(pimpl_->cfg, out)) OBFY_RETURN(true);
-                    OBFY_BREAK
-                OBFY_DONE
-                OBFY_WHEN(ModeCase{StorageMode::ENCRYPTED_FILE}) OBFY_DO
-                    if (encrypted_file::load(pimpl_->cfg, out)) OBFY_RETURN(true);
-                    OBFY_BREAK
-                OBFY_DONE
-            OBFY_ENDCASE
+            switch (mode) {
+            case StorageMode::OS_KEYCHAIN:
+                if (os_keychain::available() && os_keychain::load(pimpl_->cfg.key_id, out))
+                    return true;
+                break;
+            case StorageMode::MACHINE_BOUND:
+                if (derive_machine(pimpl_->cfg, out))
+                    return true;
+                break;
+            case StorageMode::ENCRYPTED_FILE:
+                if (encrypted_file::load(pimpl_->cfg, out))
+                    return true;
+                break;
+            }
         }
-        OBFY_RETURN(false);
-        OBFY_END_CODE
+        return false;
     }
-    
+
     bool Provider::ensure(std::vector<uint8_t>& out) {
-        OBFY_BEGIN_CODE
         std::vector<StorageMode> chain = {pimpl_->cfg.primary};
         chain.insert(chain.end(), pimpl_->cfg.fallbacks.begin(), pimpl_->cfg.fallbacks.end());
         for (auto mode : chain) {
-            ModeCase current(mode);
-            OBFY_CASE(current)
-                OBFY_WHEN(ModeCase{StorageMode::OS_KEYCHAIN}) OBFY_DO
-                    OBFY_IF(os_keychain::available())
-                        if (OBFY_CALL(os_keychain::load, pimpl_->cfg.key_id, out)) OBFY_RETURN(true);
-                        auto p = hmac_cpp::random_bytes(32);
-                        if (p.size() != 32) OBFY_RETURN(false); // ERR_RNG
-                        if (OBFY_CALL(os_keychain::store, pimpl_->cfg.key_id, p)) { out = p; OBFY_RETURN(true); }
-                    OBFY_ENDIF
-                    OBFY_BREAK
-                OBFY_DONE
-                OBFY_WHEN(ModeCase{StorageMode::MACHINE_BOUND}) OBFY_DO
-                    if (derive_machine(pimpl_->cfg, out)) OBFY_RETURN(true);
-                    OBFY_BREAK
-                OBFY_DONE
-                OBFY_WHEN(ModeCase{StorageMode::ENCRYPTED_FILE}) OBFY_DO
-                    if (encrypted_file::load(pimpl_->cfg, out)) OBFY_RETURN(true);
+            switch (mode) {
+            case StorageMode::OS_KEYCHAIN:
+                if (os_keychain::available()) {
+                    if (os_keychain::load(pimpl_->cfg.key_id, out))
+                        return true;
                     auto p = hmac_cpp::random_bytes(32);
-                    if (p.size() != 32) OBFY_RETURN(false); // ERR_RNG
-                    if (encrypted_file::store(pimpl_->cfg, p)) { out = p; OBFY_RETURN(true); }
-                    OBFY_BREAK
-                OBFY_DONE
-            OBFY_ENDCASE
+                    if (p.size() != 32)
+                        return false;
+                    if (os_keychain::store(pimpl_->cfg.key_id, p)) {
+                        out = p;
+                        return true;
+                    }
+                }
+                break;
+            case StorageMode::MACHINE_BOUND:
+                if (derive_machine(pimpl_->cfg, out))
+                    return true;
+                break;
+            case StorageMode::ENCRYPTED_FILE:
+                if (encrypted_file::load(pimpl_->cfg, out))
+                    return true;
+                {
+                    auto p = hmac_cpp::random_bytes(32);
+                    if (p.size() != 32)
+                        return false;
+                    if (encrypted_file::store(pimpl_->cfg, p)) {
+                        out = p;
+                        return true;
+                    }
+                }
+                break;
+            }
         }
-        OBFY_RETURN(false);
-        OBFY_END_CODE
+        return false;
     }
 
 } // namespace pepper


### PR DESCRIPTION
## Summary
- add write_vault and read_vault helpers for simple, json, and JWR examples
- update example mains to use new vault helpers
- remove obfy macros from provider to prevent null dereference under AddressSanitizer

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68c0b86b652c832c98e452611efc9ea5