### PR TITLE
refactor(security): protect sensitive strings

### DIFF
--- a/examples/json_vault.cpp
+++ b/examples/json_vault.cpp
@@ -113,7 +113,9 @@ static expected<VaultFile, VaultError> parse_vault(const std::string& s) {
         vf.iters = jk.at("iters").get<uint32_t>();
         if (vf.iters < 100000 || vf.iters > 1000000)
             return VaultError::ERR_KDF_PARAM;
-        auto salt_res = b64dec(jk.at("salt").get<std::string>());
+        std::string salt_b64 = jk.at("salt").get<std::string>();
+        auto salt_res = b64dec(salt_b64);
+        hmac_cpp::secure_zero(&salt_b64[0], salt_b64.size());
         if (std::holds_alternative<VaultError>(salt_res))
             return std::get<VaultError>(salt_res);
         vf.salt = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(salt_res));
@@ -122,16 +124,22 @@ static expected<VaultFile, VaultError> parse_vault(const std::string& s) {
         auto ja = j.at("aead");
         if (ja.at("alg").get<std::string>() != "aes-256-gcm")
             return VaultError::ERR_FORMAT;
-        auto iv_res = b64dec(ja.at("iv").get<std::string>());
+        std::string iv_b64 = ja.at("iv").get<std::string>();
+        auto iv_res = b64dec(iv_b64);
+        hmac_cpp::secure_zero(&iv_b64[0], iv_b64.size());
         if (std::holds_alternative<VaultError>(iv_res))
             return std::get<VaultError>(iv_res);
         vf.iv = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(iv_res));
         if (vf.iv.size() != 12) return VaultError::ERR_FORMAT;
-        auto ct_res = b64dec(ja.at("ct").get<std::string>());
+        std::string ct_b64 = ja.at("ct").get<std::string>();
+        auto ct_res = b64dec(ct_b64);
+        hmac_cpp::secure_zero(&ct_b64[0], ct_b64.size());
         if (std::holds_alternative<VaultError>(ct_res))
             return std::get<VaultError>(ct_res);
         vf.ct = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(ct_res));
-        auto tag_res = b64dec(ja.at("tag").get<std::string>());
+        std::string tag_b64 = ja.at("tag").get<std::string>();
+        auto tag_res = b64dec(tag_b64);
+        hmac_cpp::secure_zero(&tag_b64[0], tag_b64.size());
         if (std::holds_alternative<VaultError>(tag_res))
             return std::get<VaultError>(tag_res);
         vf.tag = std::get<hmac_cpp::secure_buffer<uint8_t, true>>(std::move(tag_res));
@@ -144,10 +152,10 @@ static expected<VaultFile, VaultError> parse_vault(const std::string& s) {
 }
 
 static expected<hmac_cpp::secure_buffer<uint8_t, true>, VaultError>
-derive_key(const std::string& password,
+derive_key(const hmac_cpp::secret_string& password,
            const hmac_cpp::secure_buffer<uint8_t, true>& salt,
            uint32_t iters) {
-    std::string pw_copy(password);
+    std::string pw_copy = password.reveal_copy();
     hmac_cpp::secure_buffer<uint8_t, true> pw(std::move(pw_copy));
     auto pep_res = app_pepper();
     if (std::holds_alternative<VaultError>(pep_res))
@@ -161,9 +169,9 @@ derive_key(const std::string& password,
 }
 
 static expected<VaultFile, VaultError>
-create_vault(const std::string& master_password,
+create_vault(const hmac_cpp::secret_string& master_password,
              const std::string& email,
-             const std::string& password,
+             const hmac_cpp::secret_string& password,
              uint32_t iters = 300000,
              const std::string& aad = "app=demo;v=1") {
     VaultFile vf;
@@ -179,7 +187,9 @@ create_vault(const std::string& master_password,
     std::array<uint8_t,32> key_arr{};
     std::copy(key.begin(), key.begin()+key_arr.size(), key_arr.begin());
 
-    json payload = { {"email", email}, {"password", password} };
+    std::string pass_copy = password.reveal_copy();
+    json payload = { {"email", email}, {"password", pass_copy} };
+    hmac_cpp::secure_zero(&pass_copy[0], pass_copy.size());
     std::string payload_str = payload.dump();
     hmac_cpp::secure_buffer<uint8_t, true> plain(std::move(payload_str));
 
@@ -196,7 +206,7 @@ create_vault(const std::string& master_password,
 }
 
 static expected<json, VaultError>
-open_vault(const std::string& master_password, const VaultFile& vf) {
+open_vault(const hmac_cpp::secret_string& master_password, const VaultFile& vf) {
     auto key_res = derive_key(master_password, vf.salt, vf.iters);
     if (std::holds_alternative<VaultError>(key_res))
         return std::get<VaultError>(key_res);
@@ -211,9 +221,9 @@ open_vault(const std::string& master_password, const VaultFile& vf) {
     std::vector<uint8_t> aad_bytes(vf.aad.begin(), vf.aad.end());
     std::vector<uint8_t> ct_vec(vf.ct.begin(), vf.ct.end());
     aes_cpp::utils::GcmEncryptedData pkt{std::chrono::system_clock::now(), iv, ct_vec, tag};
-    std::string plain;
+    std::vector<uint8_t> plain_vec;
     try {
-        plain = aes_cpp::utils::decrypt_gcm_to_string(pkt, key_arr, aad_bytes);
+        plain_vec = aes_cpp::utils::decrypt_gcm(pkt, key_arr, aad_bytes);
     } catch (...) {
         hmac_cpp::secure_zero(key_arr.data(), key_arr.size());
         hmac_cpp::secure_zero(ct_vec.data(), ct_vec.size());
@@ -222,18 +232,18 @@ open_vault(const std::string& master_password, const VaultFile& vf) {
     hmac_cpp::secure_zero(key_arr.data(), key_arr.size());
     hmac_cpp::secure_zero(ct_vec.data(), ct_vec.size());
     try {
-        auto j = json::parse(plain);
-        hmac_cpp::secure_zero(&plain[0], plain.size());
+        auto j = json::parse(plain_vec.begin(), plain_vec.end());
+        hmac_cpp::secure_zero(plain_vec.data(), plain_vec.size());
         return j;
     } catch (...) {
-        hmac_cpp::secure_zero(&plain[0], plain.size());
+        hmac_cpp::secure_zero(plain_vec.data(), plain_vec.size());
         return VaultError::ERR_FORMAT;
     }
 }
 
 bool write_vault(const std::string& path,
                  const std::string& email,
-                 const std::string& passphrase,
+                 const hmac_cpp::secret_string& passphrase,
                  Pepper& pepper) {
     (void)pepper;
     auto aad_tmp = OBFY_BYTES_ONCE("app://secrets/blob/v1");
@@ -252,8 +262,8 @@ bool write_vault(const std::string& path,
 
 bool read_vault(const std::string& path,
                 std::string& out_email,
-                std::string& out_password,
-                const std::string& passphrase,
+                hmac_cpp::secret_string& out_password,
+                const hmac_cpp::secret_string& passphrase,
                 Pepper& pepper) {
     (void)pepper;
     std::ifstream ifs(path);
@@ -273,7 +283,9 @@ bool read_vault(const std::string& path,
     }
     auto payload = std::get<json>(std::move(payload_res));
     out_email = payload.at("email").get<std::string>();
-    out_password = payload.at("password").get<std::string>();
+    std::string pwd_tmp = payload.at("password").get<std::string>();
+    out_password = hmac_cpp::secret_string(pwd_tmp);
+    hmac_cpp::secure_zero(&pwd_tmp[0], pwd_tmp.size());
     return true;
 }
 
@@ -290,11 +302,16 @@ int main(int argc, char** argv) {
         return 1;
     }
     Pepper& prov = provider();
-    if (!write_vault(pos[0], pos[1], pos[2], prov)) return 1;
-    std::string out_email, out_password;
-    if (!read_vault(pos[0], out_email, out_password, pos[2], prov)) return 1;
+    hmac_cpp::secret_string passphrase(pos[2]);
+    hmac_cpp::secure_zero(&pos[2][0], pos[2].size());
+    if (!write_vault(pos[0], pos[1], passphrase, prov)) return 1;
+    std::string out_email;
+    hmac_cpp::secret_string out_password;
+    if (!read_vault(pos[0], out_email, out_password, passphrase, prov)) return 1;
     std::cout << "Decrypted email: "    << out_email << "\n";
-    std::cout << "Decrypted password: " << out_password << "\n";
+    auto pass_out = out_password.reveal_copy();
+    std::cout << "Decrypted password: " << pass_out << "\n";
+    hmac_cpp::secure_zero(&pass_out[0], pass_out.size());
     return 0;
 }
 

--- a/examples/simple.cpp
+++ b/examples/simple.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <algorithm>
 #include <stdexcept>
+#include <cstring>
 
 #include <aes_cpp/aes_utils.hpp>
 #include <hmac_cpp/hmac_utils.hpp>
@@ -80,17 +81,19 @@ static std::vector<std::string> split(const std::string& s, char delim) {
 
 bool write_vault(const std::string& path,
                  const std::string& email,
-                 const std::string& passphrase,
+                 const hmac_cpp::secret_string& passphrase,
                  Pepper& pepper) {
     (void)pepper;
     try {
-        hmac_cpp::secret_string master(passphrase);
+        const hmac_cpp::secret_string& master = passphrase;
         const uint32_t iters = 300000;
         auto aad_tmp = OBFY_BYTES_ONCE("demo1");
         hmac_cpp::secure_buffer<uint8_t, true> aad_buf(
             std::vector<uint8_t>(aad_tmp.data(), aad_tmp.data() + aad_tmp.size()));
 
-        std::string payload = email + ":" + passphrase;
+        std::string pass_copy = passphrase.reveal_copy();
+        std::string payload = email + ":" + pass_copy;
+        hmac_cpp::secure_zero(&pass_copy[0], pass_copy.size());
         std::vector<uint8_t> payload_vec(payload.begin(), payload.end());
         hmac_cpp::secure_buffer<uint8_t, true> plain_buf(std::move(payload_vec));
         hmac_cpp::secure_zero(&payload[0], payload.size());
@@ -125,12 +128,12 @@ bool write_vault(const std::string& path,
 
 bool read_vault(const std::string& path,
                 std::string& out_email,
-                std::string& out_password,
-                const std::string& passphrase,
+                hmac_cpp::secret_string& out_password,
+                const hmac_cpp::secret_string& passphrase,
                 Pepper& pepper) {
     (void)pepper;
     try {
-        hmac_cpp::secret_string master(passphrase);
+        const hmac_cpp::secret_string& master = passphrase;
         std::string in;
         std::ifstream(path) >> in;
         auto parts = split(in, ':');
@@ -139,9 +142,13 @@ bool read_vault(const std::string& path,
 
         uint32_t iters = static_cast<uint32_t>(std::stoul(parts[0]));
         auto salt = b64dec(parts[1]);
+        hmac_cpp::secure_zero(&parts[1][0], parts[1].size());
         auto iv   = b64dec(parts[2]);
+        hmac_cpp::secure_zero(&parts[2][0], parts[2].size());
         auto tag  = b64dec(parts[3]);
+        hmac_cpp::secure_zero(&parts[3][0], parts[3].size());
         auto ct   = b64dec(parts[4]);
+        hmac_cpp::secure_zero(&parts[4][0], parts[4].size());
 
         auto key = derive_key(master, salt, iters);
 
@@ -153,15 +160,16 @@ bool read_vault(const std::string& path,
         packet.ciphertext = ct_vec;
         std::copy(tag.begin(), tag.begin()+packet.tag.size(), packet.tag.begin());
 
-        std::string plain = aes_cpp::utils::decrypt_gcm_to_string(packet, key, aad_bytes);
+        auto plain_vec = aes_cpp::utils::decrypt_gcm(packet, key, aad_bytes);
         hmac_cpp::secure_zero(key.data(), key.size());
         hmac_cpp::secure_zero(ct_vec.data(), ct_vec.size());
-
-        auto fields = split(plain, ':');
-        hmac_cpp::secure_zero(&plain[0], plain.size());
+        auto fields = split(std::string(plain_vec.begin(), plain_vec.end()), ':');
+        hmac_cpp::secure_zero(plain_vec.data(), plain_vec.size());
         if (fields.size() != 2) return false;
         out_email = fields[0];
-        out_password = fields[1];
+        std::string pwd_tmp = fields[1];
+        out_password = hmac_cpp::secret_string(pwd_tmp);
+        hmac_cpp::secure_zero(&pwd_tmp[0], pwd_tmp.size());
         hmac_cpp::secure_zero(aad_bytes.data(), aad_bytes.size());
         return true;
     } catch (...) {
@@ -180,11 +188,16 @@ int main(int argc, char** argv) {
     auto s_tmp = OBFY_BYTES_ONCE("\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10");
     cfg.app_salt = std::vector<uint8_t>(s_tmp.data(), s_tmp.data()+s_tmp.size());
     Pepper prov(cfg);
-    if (!write_vault(argv[1], argv[2], argv[3], prov)) return 1;
-    std::string out_email, out_password;
-    if (!read_vault(argv[1], out_email, out_password, argv[3], prov)) return 1;
+    hmac_cpp::secret_string passphrase(argv[3]);
+    hmac_cpp::secure_zero(argv[3], std::strlen(argv[3]));
+    if (!write_vault(argv[1], argv[2], passphrase, prov)) return 1;
+    std::string out_email;
+    hmac_cpp::secret_string out_password;
+    if (!read_vault(argv[1], out_email, out_password, passphrase, prov)) return 1;
     std::cout << "Decrypted email: "    << out_email << std::endl;
-    std::cout << "Decrypted password: " << out_password << std::endl;
+    auto pass_out = out_password.reveal_copy();
+    std::cout << "Decrypted password: " << pass_out << std::endl;
+    hmac_cpp::secure_zero(&pass_out[0], pass_out.size());
     return 0;
 }
 

--- a/test/test_vault.cpp
+++ b/test/test_vault.cpp
@@ -17,41 +17,44 @@
 #include "json.hpp"
 using json = nlohmann::json;
 
-using namespace aes_cpp;
-using namespace hmac_cpp;
-
-static std::string pepper() { return std::string(OBFY_STR("demo_pepper")); }
+static hmac_cpp::secure_buffer<uint8_t, true> pepper() {
+    return hmac_cpp::secure_buffer<uint8_t, true>(std::string(OBFY_STR("demo_pepper")));
+}
 
 static std::string b64enc(const hmac_cpp::secure_buffer<uint8_t, true>& v){
     return hmac_cpp::base64_encode(v.data(), v.size());
 }
-static hmac_cpp::secure_buffer<uint8_t, true> b64dec(const std::string& s){
-    std::vector<uint8_t> tmp; if(!hmac_cpp::base64_decode(s,tmp)) throw std::runtime_error("b64"); return hmac_cpp::secure_buffer<uint8_t, true>(std::move(tmp)); }
+static hmac_cpp::secure_buffer<uint8_t, true> b64dec(std::string s){
+    std::vector<uint8_t> tmp; if(!hmac_cpp::base64_decode(s,tmp)) throw std::runtime_error("b64"); hmac_cpp::secure_zero(&s[0], s.size()); return hmac_cpp::secure_buffer<uint8_t, true>(std::move(tmp)); }
 
-static hmac_cpp::secure_buffer<uint8_t, true> derive_key(const std::string& password,
+static hmac_cpp::secure_buffer<uint8_t, true> derive_key(const hmac_cpp::secret_string& password,
                                                          const hmac_cpp::secure_buffer<uint8_t, true>& salt,
                                                          uint32_t iters) {
-    std::string pw_copy(password);
+    std::string pw_copy = password.reveal_copy();
     hmac_cpp::secure_buffer<uint8_t, true> pw(std::move(pw_copy));
-    hmac_cpp::secure_buffer<uint8_t, true> pep{std::string(pepper())};
-    auto vec = pbkdf2_with_pepper(pw.data(), pw.size(),
-                                  salt.data(), salt.size(),
-                                  pep.data(), pep.size(),
-                                  iters, 32);
+    auto pep = pepper();
+    auto vec = hmac_cpp::pbkdf2_with_pepper(pw.data(), pw.size(),
+                                            salt.data(), salt.size(),
+                                            pep.data(), pep.size(),
+                                            iters, 32);
     return hmac_cpp::secure_buffer<uint8_t, true>(std::move(vec));
 }
 
 static void test_simple() {
-    const std::string master = "m";
-    const std::string payload = "a:b";
+    const hmac_cpp::secret_string master("m");
+    const hmac_cpp::secret_string payload("a:b");
     const uint32_t iters = 1000;
     const std::string aad = "t";
 
-    hmac_cpp::secure_buffer<uint8_t, true> salt(random_bytes(16));
+    hmac_cpp::secure_buffer<uint8_t, true> salt(hmac_cpp::random_bytes(16));
     auto key  = derive_key(master, salt, iters);
     std::array<uint8_t,32> key_arr{}; std::copy(key.begin(), key.begin()+key_arr.size(), key_arr.begin());
     std::vector<uint8_t> aad_bytes(aad.begin(), aad.end());
-    auto enc = utils::encrypt_gcm(payload, key_arr, aad_bytes);
+    std::string payload_copy = payload.reveal_copy();
+    std::vector<uint8_t> payload_vec(payload_copy.begin(), payload_copy.end());
+    hmac_cpp::secure_zero(&payload_copy[0], payload_copy.size());
+    auto enc = aes_cpp::utils::encrypt_gcm(payload_vec, key_arr, aad_bytes);
+    hmac_cpp::secure_zero(payload_vec.data(), payload_vec.size());
     std::string serialized = std::to_string(iters) + ":" +
        b64enc(salt) + ":" +
        b64enc(hmac_cpp::secure_buffer<uint8_t,true>(std::vector<uint8_t>(enc.iv.begin(), enc.iv.end()))) + ":" +
@@ -61,22 +64,22 @@ static void test_simple() {
     while (std::getline(ss, item, ':')) parts.push_back(item);
     assert(parts.size()==5);
     uint32_t iters2 = static_cast<uint32_t>(std::stoul(parts[0]));
-    auto salt2 = b64dec(parts[1]);
-    auto iv2 = b64dec(parts[2]);
-    auto tag2 = b64dec(parts[3]);
-    auto ct2 = b64dec(parts[4]);
+    auto salt2 = b64dec(parts[1]); hmac_cpp::secure_zero(&parts[1][0], parts[1].size());
+    auto iv2 = b64dec(parts[2]);   hmac_cpp::secure_zero(&parts[2][0], parts[2].size());
+    auto tag2 = b64dec(parts[3]);  hmac_cpp::secure_zero(&parts[3][0], parts[3].size());
+    auto ct2 = b64dec(parts[4]);   hmac_cpp::secure_zero(&parts[4][0], parts[4].size());
     auto key2 = derive_key(master, salt2, iters2);
     std::array<uint8_t,32> key2_arr{}; std::copy(key2.begin(), key2.begin()+key2_arr.size(), key2_arr.begin());
-    utils::GcmEncryptedData packet;
+    aes_cpp::utils::GcmEncryptedData packet;
     std::copy(iv2.begin(), iv2.begin()+packet.iv.size(), packet.iv.begin());
     packet.ciphertext = std::vector<uint8_t>(ct2.begin(), ct2.end());
     std::copy(tag2.begin(), tag2.begin()+packet.tag.size(), packet.tag.begin());
-    auto plain = utils::decrypt_gcm_to_string(packet, key2_arr, aad_bytes);
+    auto plain_vec = aes_cpp::utils::decrypt_gcm(packet, key2_arr, aad_bytes);
 
     packet.tag[0] ^= 1;
     bool failed = false;
     try {
-        auto fail_plain = utils::decrypt_gcm(packet, key2_arr, aad_bytes);
+        auto fail_plain = aes_cpp::utils::decrypt_gcm(packet, key2_arr, aad_bytes);
         if (!fail_plain.empty()) {
             hmac_cpp::secure_zero(fail_plain.data(), fail_plain.size());
         }
@@ -87,8 +90,10 @@ static void test_simple() {
 
     hmac_cpp::secure_zero(key_arr.data(), key_arr.size());
     hmac_cpp::secure_zero(key2_arr.data(), key2_arr.size());
-    hmac_cpp::secure_buffer<uint8_t, true> plain_buf(std::move(plain));
-    hmac_cpp::secure_buffer<uint8_t, true> payload_buf{std::string(payload)};
+    hmac_cpp::secure_buffer<uint8_t, true> plain_buf(std::move(plain_vec));
+    std::string payload_cmp = payload.reveal_copy();
+    hmac_cpp::secure_buffer<uint8_t, true> payload_buf(std::move(payload_cmp));
+    hmac_cpp::secure_zero(&payload_cmp[0], payload_cmp.size());
     assert(hmac_cpp::constant_time_equal(plain_buf.data(), plain_buf.size(),
                                         payload_buf.data(), payload_buf.size()));
 }
@@ -118,59 +123,74 @@ static VaultFile parse_vault(const std::string& s) {
     if(jk.at("alg").get<std::string>()!="pbkdf2-hmac-sha256") throw std::runtime_error("bad kdf alg");
     vf.iters=jk.at("iters").get<uint32_t>();
     if(vf.iters<100000||vf.iters>1000000) throw std::runtime_error("bad iters");
-    vf.salt=b64dec(jk.at("salt").get<std::string>());
+    std::string salt_b64 = jk.at("salt").get<std::string>();
+    vf.salt=b64dec(salt_b64); hmac_cpp::secure_zero(&salt_b64[0], salt_b64.size());
     if(vf.salt.size()<16||vf.salt.size()>32) throw std::runtime_error("bad salt size");
     auto ja=j.at("aead");
     if(ja.at("alg").get<std::string>()!="aes-256-gcm") throw std::runtime_error("bad aead alg");
-    vf.iv=b64dec(ja.at("iv").get<std::string>()); if(vf.iv.size()!=12) throw std::runtime_error("bad iv size");
-    vf.ct=b64dec(ja.at("ct").get<std::string>());
-    vf.tag=b64dec(ja.at("tag").get<std::string>()); if(vf.tag.size()!=16) throw std::runtime_error("bad tag size");
+    std::string iv_b64 = ja.at("iv").get<std::string>();
+    vf.iv=b64dec(iv_b64); hmac_cpp::secure_zero(&iv_b64[0], iv_b64.size()); if(vf.iv.size()!=12) throw std::runtime_error("bad iv size");
+    std::string ct_b64 = ja.at("ct").get<std::string>();
+    vf.ct=b64dec(ct_b64); hmac_cpp::secure_zero(&ct_b64[0], ct_b64.size());
+    std::string tag_b64 = ja.at("tag").get<std::string>();
+    vf.tag=b64dec(tag_b64); hmac_cpp::secure_zero(&tag_b64[0], tag_b64.size()); if(vf.tag.size()!=16) throw std::runtime_error("bad tag size");
     vf.aad=ja.value("aad","");
     return vf;
 }
-static VaultFile create_vault(const std::string& master,const std::string& email,const std::string& password,uint32_t iters,const std::string& aad){
-    VaultFile vf; vf.v=1; vf.iters=iters; auto salt_vec=random_bytes(16); if(salt_vec.size()!=16) throw std::runtime_error("rng"); vf.salt=hmac_cpp::secure_buffer<uint8_t,true>(std::move(salt_vec)); auto key=derive_key(master,vf.salt,iters); std::array<uint8_t,32> key_arr{}; std::copy(key.begin(),key.begin()+key_arr.size(),key_arr.begin()); json payload={{"email",email},{"password",password}}; std::string payload_str=payload.dump(); hmac_cpp::secure_buffer<uint8_t,true> plain(std::move(payload_str)); std::vector<uint8_t> aadb(aad.begin(),aad.end()); std::vector<uint8_t> plain_vec(plain.begin(),plain.end()); auto enc=utils::encrypt_gcm(plain_vec,key_arr,aadb); hmac_cpp::secure_zero(key_arr.data(),key_arr.size()); hmac_cpp::secure_zero(plain_vec.data(),plain_vec.size()); vf.iv=hmac_cpp::secure_buffer<uint8_t,true>(std::vector<uint8_t>(enc.iv.begin(),enc.iv.end())); vf.ct=hmac_cpp::secure_buffer<uint8_t,true>(std::move(enc.ciphertext)); vf.tag=hmac_cpp::secure_buffer<uint8_t,true>(std::vector<uint8_t>(enc.tag.begin(),enc.tag.end())); vf.aad=aad; return vf; }
-static json open_vault(const std::string& master,const VaultFile& vf){ auto key=derive_key(master,vf.salt,vf.iters); std::array<uint8_t,32> key_arr{}; std::copy(key.begin(),key.begin()+key_arr.size(),key_arr.begin()); std::array<uint8_t,12> iv{}; std::copy(vf.iv.begin(),vf.iv.begin()+iv.size(),iv.begin()); std::array<uint8_t,16> tag{}; std::copy(vf.tag.begin(),vf.tag.begin()+tag.size(),tag.begin()); std::vector<uint8_t> aadb(vf.aad.begin(),vf.aad.end()); std::vector<uint8_t> ct_vec(vf.ct.begin(),vf.ct.end()); utils::GcmEncryptedData pkt{std::chrono::system_clock::now(),iv,ct_vec,tag}; auto plain=utils::decrypt_gcm_to_string(pkt,key_arr,aadb); hmac_cpp::secure_zero(key_arr.data(),key_arr.size()); hmac_cpp::secure_zero(ct_vec.data(),ct_vec.size()); auto r=json::parse(plain); hmac_cpp::secure_zero(&plain[0],plain.size()); return r; }
+static VaultFile create_vault(const hmac_cpp::secret_string& master,const std::string& email,const hmac_cpp::secret_string& password,uint32_t iters,const std::string& aad){
+    VaultFile vf; vf.v=1; vf.iters=iters; auto salt_vec=hmac_cpp::random_bytes(16); if(salt_vec.size()!=16) throw std::runtime_error("rng"); vf.salt=hmac_cpp::secure_buffer<uint8_t,true>(std::move(salt_vec)); auto key=derive_key(master,vf.salt,iters); std::array<uint8_t,32> key_arr{}; std::copy(key.begin(),key.begin()+key_arr.size(),key_arr.begin()); std::string pass_copy=password.reveal_copy(); json payload={{"email",email},{"password",pass_copy}}; hmac_cpp::secure_zero(&pass_copy[0],pass_copy.size()); std::string payload_str=payload.dump(); hmac_cpp::secure_buffer<uint8_t,true> plain(std::move(payload_str)); std::vector<uint8_t> aadb(aad.begin(),aad.end()); std::vector<uint8_t> plain_vec(plain.begin(),plain.end()); auto enc=aes_cpp::utils::encrypt_gcm(plain_vec,key_arr,aadb); hmac_cpp::secure_zero(key_arr.data(),key_arr.size()); hmac_cpp::secure_zero(plain_vec.data(),plain_vec.size()); vf.iv=hmac_cpp::secure_buffer<uint8_t,true>(std::vector<uint8_t>(enc.iv.begin(),enc.iv.end())); vf.ct=hmac_cpp::secure_buffer<uint8_t,true>(std::move(enc.ciphertext)); vf.tag=hmac_cpp::secure_buffer<uint8_t,true>(std::vector<uint8_t>(enc.tag.begin(),enc.tag.end())); vf.aad=aad; return vf; }
+static json open_vault(const hmac_cpp::secret_string& master,const VaultFile& vf){ auto key=derive_key(master,vf.salt,vf.iters); std::array<uint8_t,32> key_arr{}; std::copy(key.begin(),key.begin()+key_arr.size(),key_arr.begin()); std::array<uint8_t,12> iv{}; std::copy(vf.iv.begin(),vf.iv.begin()+iv.size(),iv.begin()); std::array<uint8_t,16> tag{}; std::copy(vf.tag.begin(),vf.tag.begin()+tag.size(),tag.begin()); std::vector<uint8_t> aadb(vf.aad.begin(),vf.aad.end()); std::vector<uint8_t> ct_vec(vf.ct.begin(),vf.ct.end()); aes_cpp::utils::GcmEncryptedData pkt{std::chrono::system_clock::now(),iv,ct_vec,tag}; auto plain_vec=aes_cpp::utils::decrypt_gcm(pkt,key_arr,aadb); hmac_cpp::secure_zero(key_arr.data(),key_arr.size()); hmac_cpp::secure_zero(ct_vec.data(),ct_vec.size()); auto r=json::parse(plain_vec.begin(),plain_vec.end()); hmac_cpp::secure_zero(plain_vec.data(),plain_vec.size()); return r; }
 
 static std::string b64url_encode(const hmac_cpp::secure_buffer<uint8_t, true>& d){ auto s=b64enc(d); std::replace(s.begin(),s.end(),'+','-'); std::replace(s.begin(),s.end(),'/','_'); while(!s.empty()&&s.back()=='=') s.pop_back(); return s; }
-static hmac_cpp::secure_buffer<uint8_t, true> b64url_decode(const std::string& s){ std::string t=s; std::replace(t.begin(),t.end(),'-','+'); std::replace(t.begin(),t.end(),'_','/'); while(t.size()%4) t.push_back('='); return b64dec(t); }
+static hmac_cpp::secure_buffer<uint8_t, true> b64url_decode(std::string s){ std::string t=s; hmac_cpp::secure_zero(&s[0],s.size()); std::replace(t.begin(),t.end(),'-','+'); std::replace(t.begin(),t.end(),'_','/'); while(t.size()%4) t.push_back('='); auto r=b64dec(t); hmac_cpp::secure_zero(&t[0],t.size()); return r; }
 
 static void test_json(){
-    const std::string master="m", email="e", pass="p";
+    const hmac_cpp::secret_string master("m"); const std::string email="e"; const hmac_cpp::secret_string pass("p");
     auto vf=create_vault(master,email,pass,100000,"t");
     auto text=serialize_vault(vf);
     auto parsed=parse_vault(text);
     auto payload=open_vault(master,parsed);
     auto email_dec = payload.at("email").get<std::string>();
-    auto pass_dec = payload.at("password").get<std::string>();
+    auto pass_dec_tmp = payload.at("password").get<std::string>();
     hmac_cpp::secure_buffer<uint8_t, true> email_buf(std::move(email_dec));
     hmac_cpp::secure_buffer<uint8_t, true> email_exp{std::string(email)};
     assert(hmac_cpp::constant_time_equal(email_buf.data(), email_buf.size(),
                                         email_exp.data(), email_exp.size()));
-    hmac_cpp::secure_buffer<uint8_t, true> pass_buf(std::move(pass_dec));
-    hmac_cpp::secure_buffer<uint8_t, true> pass_exp{std::string(pass)};
+    hmac_cpp::secure_buffer<uint8_t, true> pass_buf(std::move(pass_dec_tmp));
+    hmac_cpp::secure_zero(&pass_dec_tmp[0], pass_dec_tmp.size());
+    auto pass_exp_copy = pass.reveal_copy();
+    hmac_cpp::secure_buffer<uint8_t, true> pass_exp(std::move(pass_exp_copy));
+    hmac_cpp::secure_zero(&pass_exp_copy[0], pass_exp_copy.size());
     assert(hmac_cpp::constant_time_equal(pass_buf.data(), pass_buf.size(),
                                         pass_exp.data(), pass_exp.size()));
 }
 
 static void test_jwr(){
-    const std::string master="m", email="e", pass="p";
+    const hmac_cpp::secret_string master("m"); const std::string email="e"; const hmac_cpp::secret_string pass("p");
     auto vf=create_vault(master,email,pass,100000,"t");
     std::string header=json({{"typ","JWR"}}).dump();
     std::string body=serialize_vault(vf);
     std::string token=b64url_encode(hmac_cpp::secure_buffer<uint8_t,true>(std::string(header)))+"."+b64url_encode(hmac_cpp::secure_buffer<uint8_t,true>(std::string(body)));
     auto pos=token.find('.'); assert(pos!=std::string::npos);
-    auto body_bytes=b64url_decode(token.substr(pos+1));
-    auto parsed=parse_vault(std::string(body_bytes.begin(),body_bytes.end()));
+    std::string body_b64 = token.substr(pos+1);
+    auto body_bytes=b64url_decode(body_b64);
+    hmac_cpp::secure_zero(&body_b64[0], body_b64.size());
+    std::string body_str(body_bytes.begin(),body_bytes.end());
+    auto parsed=parse_vault(body_str);
+    hmac_cpp::secure_zero(&body_str[0], body_str.size());
+    hmac_cpp::secure_zero(body_bytes.data(), body_bytes.size());
     auto payload=open_vault(master,parsed);
     auto email_dec = payload.at("email").get<std::string>();
-    auto pass_dec = payload.at("password").get<std::string>();
+    auto pass_dec_tmp = payload.at("password").get<std::string>();
     hmac_cpp::secure_buffer<uint8_t, true> email_buf(std::move(email_dec));
     hmac_cpp::secure_buffer<uint8_t, true> email_exp{std::string(email)};
     assert(hmac_cpp::constant_time_equal(email_buf.data(), email_buf.size(),
                                         email_exp.data(), email_exp.size()));
-    hmac_cpp::secure_buffer<uint8_t, true> pass_buf(std::move(pass_dec));
-    hmac_cpp::secure_buffer<uint8_t, true> pass_exp{std::string(pass)};
+    hmac_cpp::secure_buffer<uint8_t, true> pass_buf(std::move(pass_dec_tmp));
+    hmac_cpp::secure_zero(&pass_dec_tmp[0], pass_dec_tmp.size());
+    auto pass_exp_copy = pass.reveal_copy();
+    hmac_cpp::secure_buffer<uint8_t, true> pass_exp(std::move(pass_exp_copy));
+    hmac_cpp::secure_zero(&pass_exp_copy[0], pass_exp_copy.size());
     assert(hmac_cpp::constant_time_equal(pass_buf.data(), pass_buf.size(),
                                         pass_exp.data(), pass_exp.size()));
 }


### PR DESCRIPTION
## Summary
- replace plaintext std::string secrets with hmac_cpp::secret_string or secure_buffer
- zero Base64 source buffers after decoding
- remove using namespace directives and fully qualify calls

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c0c0ebc700832c9cf5ad995cc08106