### PR TITLE
test: cover vault read/write and fallback cases

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,19 @@
-add_executable(vault_tests test_vault.cpp)
+add_executable(vault_tests
+    test_vault.cpp
+    ../examples/pepper/pepper_provider.cpp
+    ../examples/pepper/os_keychain.cpp
+    ../examples/pepper/machine_bound.cpp
+    ../examples/pepper/encrypted_file.cpp)
+target_include_directories(vault_tests PRIVATE ../examples/pepper)
 target_link_libraries(vault_tests PRIVATE aes_cpp::aes_cpp hmac_cpp::hmac_cpp obfy)
 target_compile_options(vault_tests PRIVATE ${PROJECT_COMPILE_OPTIONS})
 target_link_options(vault_tests PRIVATE ${PROJECT_LINK_OPTIONS})
+if (APPLE)
+    target_link_libraries(vault_tests PRIVATE "-framework Security" "-framework CoreFoundation")
+endif()
+if (WIN32)
+    target_link_libraries(vault_tests PRIVATE crypt32)
+endif()
 add_test(NAME vault_tests COMMAND vault_tests)
 
 add_executable(pepper_tests

--- a/test/test_vault.cpp
+++ b/test/test_vault.cpp
@@ -384,9 +384,9 @@ static void test_bad_passphrase(){
 }
 
 static void test_pepper_fallback(){
-    pepper::Config c1; c1.primary=pepper::StorageMode::OS_KEYCHAIN; c1.fallbacks={pepper::StorageMode::MACHINE_BOUND,pepper::StorageMode::ENCRYPTED_FILE}; c1.app_salt=salt16(); c1.file_path="pepper_fb.bin";
+    pepper::Config c1; c1.primary=pepper::StorageMode::MACHINE_BOUND; c1.fallbacks={pepper::StorageMode::ENCRYPTED_FILE}; c1.app_salt=salt16(); c1.file_path="pepper_fb.bin";
     pepper::Provider p1(c1); std::vector<uint8_t> a; assert(p1.ensure(a));
-    pepper::Config c2=c1; c2.fallbacks={pepper::StorageMode::ENCRYPTED_FILE};
+    pepper::Config c2=c1; c2.primary=pepper::StorageMode::ENCRYPTED_FILE; c2.fallbacks={};
     pepper::Provider p2(c2); std::vector<uint8_t> b; assert(p2.ensure(b));
     hmac_cpp::secure_buffer<uint8_t,true> sa(std::move(a)); hmac_cpp::secure_buffer<uint8_t,true> sb(std::move(b));
     auto ms = pepper::machine_bound::get_machine_secret(c1);

--- a/test/test_vault.cpp
+++ b/test/test_vault.cpp
@@ -8,6 +8,8 @@
 #include <algorithm>
 #include <stdexcept>
 #include <chrono>
+#include <fstream>
+#include <cstdio>
 
 #include <aes_cpp/aes_utils.hpp>
 #include <hmac_cpp/hmac_utils.hpp>
@@ -17,12 +19,14 @@
 #include <obfy/obfy_str.hpp>
 #include <obfy/obfy_bytes.hpp>
 
+#include "../examples/pepper/pepper_provider.hpp"
+
 #include "json.hpp"
 using json = nlohmann::json;
 
 static const auto aad = OBFY_BYTES_ONCE("app://secrets/blob/v1");
 
-static hmac_cpp::secure_buffer<uint8_t, true> pepper() {
+static hmac_cpp::secure_buffer<uint8_t, true> demo_pepper() {
     return hmac_cpp::secure_buffer<uint8_t, true>(std::string(OBFY_STR("demo_pepper")));
 }
 
@@ -43,7 +47,7 @@ static hmac_cpp::secure_buffer<uint8_t, true> derive_key(const hmac_cpp::secret_
                                                          uint32_t iters) {
     std::string pw_copy = password.reveal_copy();
     hmac_cpp::secure_buffer<uint8_t, true> pw(std::move(pw_copy));
-    auto pep = pepper();
+    auto pep = demo_pepper();
     auto vec = hmac_cpp::pbkdf2_with_pepper(pw.data(), pw.size(),
                                             salt.data(), salt.size(),
                                             pep.data(), pep.size(),
@@ -181,6 +185,95 @@ static hmac_cpp::secure_buffer<uint8_t, true> b64url_decode(std::string s){
     hmac_cpp::secure_zero(&t[0],t.size()); return r;
 }
 
+static std::vector<std::string> split(const std::string& s, char delim){
+    std::vector<std::string> parts; std::stringstream ss(s); std::string item;
+    while(std::getline(ss,item,delim)) parts.push_back(item); return parts;
+}
+
+static std::vector<uint8_t> salt16(){
+    std::vector<uint8_t> s(16); for(size_t i=0;i<s.size();++i) s[i]=static_cast<uint8_t>(i+1); return s;
+}
+
+static std::array<uint8_t,32> derive_key_prov(const hmac_cpp::secret_string& password,
+                                              const hmac_cpp::secure_buffer<uint8_t, true>& salt,
+                                              uint32_t iters,
+                                              pepper::Provider& prov){
+    std::vector<uint8_t> pep_tmp; if(!prov.ensure(pep_tmp)) throw std::runtime_error("pepper");
+    hmac_cpp::secure_buffer<uint8_t, true> pep(std::move(pep_tmp));
+    std::string pw_copy=password.reveal_copy();
+    hmac_cpp::secure_buffer<uint8_t, true> pw(std::move(pw_copy));
+    auto vec=hmac_cpp::pbkdf2_with_pepper(pw.data(),pw.size(),salt.data(),salt.size(),pep.data(),pep.size(),iters,32);
+    hmac_cpp::secure_zero(pw.data(),pw.size()); hmac_cpp::secure_zero(pep.data(),pep.size());
+    std::array<uint8_t,32> key{}; std::copy(vec.begin(),vec.end(),key.begin());
+    hmac_cpp::secure_zero(vec.data(),vec.size());
+    return key;
+}
+
+static bool write_vault(const std::string& path,
+                        const std::string& email,
+                        const hmac_cpp::secret_string& passphrase,
+                        pepper::Provider& prov){
+    try{
+        const uint32_t iters=300000;
+        std::vector<uint8_t> aad_bytes(aad.data(),aad.data()+aad.size());
+        std::string pass_copy=passphrase.reveal_copy();
+        std::string payload=email+":"+pass_copy;
+        hmac_cpp::secure_zero(&pass_copy[0],pass_copy.size());
+        std::vector<uint8_t> payload_vec(payload.begin(),payload.end());
+        hmac_cpp::secure_zero(&payload[0],payload.size());
+        auto salt_vec=hmac_cpp::random_bytes(16); if(salt_vec.size()!=16){hmac_cpp::secure_zero(salt_vec.data(),salt_vec.size()); return false;}
+        hmac_cpp::secure_buffer<uint8_t,true> salt(std::move(salt_vec));
+        auto key=derive_key_prov(passphrase,salt,iters,prov);
+        auto enc=aes_cpp::utils::encrypt_gcm(payload_vec,key,aad_bytes);
+        hmac_cpp::secure_zero(payload_vec.data(),payload_vec.size());
+        hmac_cpp::secure_zero(key.data(),key.size());
+        hmac_cpp::secure_zero(aad_bytes.data(),aad_bytes.size());
+        auto iv=hmac_cpp::secure_buffer<uint8_t,true>(std::vector<uint8_t>(enc.iv.begin(),enc.iv.end()));
+        auto tag=hmac_cpp::secure_buffer<uint8_t,true>(std::vector<uint8_t>(enc.tag.begin(),enc.tag.end()));
+        auto ct=hmac_cpp::secure_buffer<uint8_t,true>(std::move(enc.ciphertext));
+        std::string serialized=std::to_string(iters)+":"+b64enc(salt)+":"+b64enc(iv)+":"+b64enc(tag)+":"+b64enc(ct);
+        std::ofstream(path) << serialized;
+        hmac_cpp::secure_zero(&serialized[0],serialized.size());
+        return true;
+    }catch(...){return false;}
+}
+
+static bool read_vault(const std::string& path,
+                       std::string& out_email,
+                       hmac_cpp::secret_string& out_password,
+                       const hmac_cpp::secret_string& passphrase,
+                       pepper::Provider& prov){
+    try{
+        std::string in; std::ifstream(path) >> in;
+        auto parts=split(in,':'); hmac_cpp::secure_zero(&in[0],in.size());
+        if(parts.size()!=5) return false;
+        uint32_t iters=static_cast<uint32_t>(std::stoul(parts[0]));
+        hmac_cpp::secure_buffer<uint8_t, true> salt; if(!b64dec(parts[1],salt)) return false; hmac_cpp::secure_zero(&parts[1][0],parts[1].size());
+        hmac_cpp::secure_buffer<uint8_t, true> iv;   if(!b64dec(parts[2],iv))   return false; hmac_cpp::secure_zero(&parts[2][0],parts[2].size());
+        hmac_cpp::secure_buffer<uint8_t, true> tag;  if(!b64dec(parts[3],tag))  return false; hmac_cpp::secure_zero(&parts[3][0],parts[3].size());
+        hmac_cpp::secure_buffer<uint8_t, true> ct;   if(!b64dec(parts[4],ct))   return false; hmac_cpp::secure_zero(&parts[4][0],parts[4].size());
+        auto key=derive_key_prov(passphrase,salt,iters,prov);
+        std::vector<uint8_t> aad_bytes(aad.data(),aad.data()+aad.size());
+        aes_cpp::utils::GcmEncryptedData packet; std::copy(iv.begin(),iv.begin()+packet.iv.size(),packet.iv.begin());
+        packet.ciphertext=std::vector<uint8_t>(ct.begin(),ct.end());
+        std::copy(tag.begin(),tag.begin()+packet.tag.size(),packet.tag.begin());
+        auto plain_vec=aes_cpp::utils::decrypt_gcm(packet,key,aad_bytes);
+        hmac_cpp::secure_zero(key.data(),key.size());
+        hmac_cpp::secure_zero(aad_bytes.data(),aad_bytes.size());
+        hmac_cpp::secure_zero(packet.ciphertext.data(),packet.ciphertext.size());
+        std::string plain_str(plain_vec.begin(),plain_vec.end());
+        hmac_cpp::secure_zero(plain_vec.data(),plain_vec.size());
+        auto fields=split(plain_str,':');
+        hmac_cpp::secure_zero(&plain_str[0],plain_str.size());
+        if(fields.size()!=2) return false;
+        out_email=fields[0];
+        std::string pwd=fields[1];
+        out_password=hmac_cpp::secret_string(pwd);
+        hmac_cpp::secure_zero(&pwd[0],pwd.size());
+        return true;
+    }catch(...){return false;}
+}
+
 static void test_json(){
     const hmac_cpp::secret_string master("m"); const std::string email="e"; const hmac_cpp::secret_string pass("p");
     auto vf=create_vault(master,email,pass,100000);
@@ -232,10 +325,82 @@ static void test_jwr(){
                                         pass_exp.data(), pass_exp.size()));
 }
 
+// Verify write/read behavior and error cases.
+static void test_round_trip(){
+    pepper::Config cfg; cfg.primary=pepper::StorageMode::OS_KEYCHAIN;
+    cfg.fallbacks={pepper::StorageMode::MACHINE_BOUND,pepper::StorageMode::ENCRYPTED_FILE};
+    cfg.app_salt=salt16(); cfg.file_path="pepper_vault.bin";
+    pepper::Provider prov(cfg);
+    std::string path="vault_round.bin"; std::string email="e"; hmac_cpp::secret_string pass("p");
+    assert(write_vault(path,email,pass,prov));
+    std::string out_email; hmac_cpp::secret_string out_pass; assert(read_vault(path,out_email,out_pass,pass,prov));
+    hmac_cpp::secure_buffer<uint8_t,true> out_email_buf{std::string(out_email)};
+    hmac_cpp::secure_zero(&out_email[0],out_email.size());
+    hmac_cpp::secure_buffer<uint8_t,true> email_exp{std::string(email)};
+    assert(hmac_cpp::constant_time_equal(out_email_buf.data(),out_email_buf.size(),email_exp.data(),email_exp.size()));
+    auto out_pass_copy=out_pass.reveal_copy(); hmac_cpp::secure_buffer<uint8_t,true> out_pass_buf(std::move(out_pass_copy));
+    hmac_cpp::secure_zero(&out_pass_copy[0],out_pass_copy.size());
+    auto pass_copy=pass.reveal_copy(); hmac_cpp::secure_buffer<uint8_t,true> pass_buf(std::move(pass_copy));
+    hmac_cpp::secure_zero(&pass_copy[0],pass_copy.size());
+    assert(hmac_cpp::constant_time_equal(out_pass_buf.data(),out_pass_buf.size(),pass_buf.data(),pass_buf.size()));
+    hmac_cpp::secure_zero(out_email_buf.data(),out_email_buf.size());
+    hmac_cpp::secure_zero(email_exp.data(),email_exp.size());
+    hmac_cpp::secure_zero(out_pass_buf.data(),out_pass_buf.size());
+    hmac_cpp::secure_zero(pass_buf.data(),pass_buf.size());
+    std::remove(path.c_str()); std::remove(cfg.file_path.c_str());
+}
+
+static void test_tag_tamper(){
+    pepper::Config cfg; cfg.primary=pepper::StorageMode::OS_KEYCHAIN;
+    cfg.fallbacks={pepper::StorageMode::MACHINE_BOUND,pepper::StorageMode::ENCRYPTED_FILE};
+    cfg.app_salt=salt16(); cfg.file_path="pepper_tamper.bin";
+    pepper::Provider prov(cfg);
+    std::string path="vault_tamper.bin"; std::string email="e"; hmac_cpp::secret_string pass("p");
+    assert(write_vault(path,email,pass,prov));
+    std::string content; {std::ifstream in(path); in>>content;}
+    auto parts=split(content,':'); hmac_cpp::secure_zero(&content[0],content.size()); assert(parts.size()==5);
+    hmac_cpp::secure_buffer<uint8_t,true> tag; assert(b64dec(parts[3],tag)); tag[0]^=1; parts[3]=b64enc(tag);
+    std::string tam=parts[0]+":"+parts[1]+":"+parts[2]+":"+parts[3]+":"+parts[4];
+    std::ofstream(path) << tam; hmac_cpp::secure_zero(&tam[0],tam.size());
+    for(auto& p:parts) if(!p.empty()) hmac_cpp::secure_zero(&p[0],p.size());
+    std::string out_email; hmac_cpp::secret_string out_pass; bool ok=read_vault(path,out_email,out_pass,pass,prov);
+    assert(!ok); if(!out_email.empty()) hmac_cpp::secure_zero(&out_email[0],out_email.size());
+    auto tmp = out_pass.reveal_copy(); if(!tmp.empty()) hmac_cpp::secure_zero(&tmp[0], tmp.size());
+    std::remove(path.c_str()); std::remove(cfg.file_path.c_str());
+}
+
+static void test_bad_passphrase(){
+    pepper::Config cfg; cfg.primary=pepper::StorageMode::OS_KEYCHAIN;
+    cfg.fallbacks={pepper::StorageMode::MACHINE_BOUND,pepper::StorageMode::ENCRYPTED_FILE};
+    cfg.app_salt=salt16(); cfg.file_path="pepper_bad.bin";
+    pepper::Provider prov(cfg);
+    std::string path="vault_bad.bin"; std::string email="e"; hmac_cpp::secret_string pass("p");
+    assert(write_vault(path,email,pass,prov));
+    hmac_cpp::secret_string wrong("x"); std::string out_email; hmac_cpp::secret_string out_pass; bool ok=read_vault(path,out_email,out_pass,wrong,prov);
+    assert(!ok); if(!out_email.empty()) hmac_cpp::secure_zero(&out_email[0],out_email.size());
+    auto tmp = out_pass.reveal_copy(); if(!tmp.empty()) hmac_cpp::secure_zero(&tmp[0], tmp.size());
+    std::remove(path.c_str()); std::remove(cfg.file_path.c_str());
+}
+
+static void test_pepper_fallback(){
+    pepper::Config c1; c1.primary=pepper::StorageMode::OS_KEYCHAIN; c1.fallbacks={pepper::StorageMode::MACHINE_BOUND,pepper::StorageMode::ENCRYPTED_FILE}; c1.app_salt=salt16(); c1.file_path="pepper_fb.bin";
+    pepper::Provider p1(c1); std::vector<uint8_t> a; assert(p1.ensure(a));
+    pepper::Config c2=c1; c2.fallbacks={pepper::StorageMode::ENCRYPTED_FILE};
+    pepper::Provider p2(c2); std::vector<uint8_t> b; assert(p2.ensure(b));
+    hmac_cpp::secure_buffer<uint8_t,true> sa(std::move(a)); hmac_cpp::secure_buffer<uint8_t,true> sb(std::move(b));
+    assert(!hmac_cpp::constant_time_equal(sa.data(),sa.size(),sb.data(),sb.size()));
+    hmac_cpp::secure_zero(sa.data(),sa.size()); hmac_cpp::secure_zero(sb.data(),sb.size());
+    std::remove(c1.file_path.c_str());
+}
+
 int main(){
     test_simple();
     test_json();
     test_jwr();
+    test_round_trip();
+    test_tag_tamper();
+    test_bad_passphrase();
+    test_pepper_fallback();
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- add round-trip vault encryption/decryption tests
- ensure tampered tags and wrong passphrases fail
- exercise pepper fallback path and secure buffer cleanup

## Testing
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c1aa27a230832caa1d441406bc1879